### PR TITLE
fix(pre-command): Loop over multiple downloads instead of joining with commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ steps:
         upload: "log/**/*.log"
 ```
 
+or
+
+```yml
+steps:
+  - plugins:
+      artifacts#v1.1.0:
+        upload: [ "log/**/*.log", debug/*.error ]
+```
+
 ## Downloading artifacts
 
 This downloads artifacts matching globs to the local filesystem. See [downloading artifacts](https://buildkite.com/docs/agent/cli-artifact#downloading-artifacts) for more details.
@@ -24,15 +33,24 @@ steps:
         download: "log/**/*.log"
 ```
 
+or
+
+```yml
+steps:
+  - plugins:
+      artifacts#v1.1.0:
+        download: [ "log/**/*.log", debug/*.error ]
+```
+
 ## Configuration
 
 ### `upload`
 
-A glob pattern for files to upload.
+A glob pattern, or array of glob patterns, for files to upload.
 
 ### `download`
 
-A glob pattern for files to download.
+A glob pattern, or array of glob patterns, for files to download.
 
 ### `step` (optional)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ or
 steps:
   - plugins:
       artifacts#v1.1.0:
-        upload: [ "log/**/*.log", debug/*.error ]
+        upload: [ "log/**/*.log", "debug/*.error" ]
 ```
 
 ## Downloading artifacts
@@ -39,7 +39,7 @@ or
 steps:
   - plugins:
       artifacts#v1.1.0:
-        download: [ "log/**/*.log", debug/*.error ]
+        download: [ "log/**/*.log", "debug/*.error" ]
 ```
 
 ## Configuration

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -29,14 +29,30 @@ workdir=${BUILDKITE_PLUGIN_ARTIFACTS_WORKDIR:-.}
 pushd "${workdir}"
 trap popd EXIT
 
-if [ "${#paths[@]}" -gt 0 ]; then
+if [ "${#paths[@]}" -eq 1 ]; then
   if [ "${#args[@]}" -gt 0 ]; then
     echo "--- Uploading artifacts with args: ${args[*]}"
 
-    buildkite-agent artifact upload "${args[@]}" "$(IFS=, ; echo "${paths[*]}")"
+    buildkite-agent artifact upload "${args[@]}" "${paths[*]}"
   else
     echo "--- Uploading artifacts"
 
-    buildkite-agent artifact upload "$(IFS=, ; echo "${paths[*]}")"
+    buildkite-agent artifact upload "${paths[*]}"
+  fi
+elif [ "${#paths[@]}" -gt 1 ]; then
+  if [ "${#args[@]}" -gt 0 ]; then
+    echo "--- Uploading artifacts with args: ${args[*]}"
+
+    for path in "${paths[@]}"
+      do
+        buildkite-agent artifact upload "${args[@]}" "$path"
+      done
+  else
+    echo "--- Uploading artifacts"
+
+    for path in "${paths[@]}"
+      do
+        buildkite-agent artifact upload "$path"
+      done
   fi
 fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -34,11 +34,11 @@ if [ "${#paths[@]}" -eq 1 ]; then
   if [ "${#args[@]}" -gt 0 ]; then
     echo "--- Downloading artifacts with args: ${args[*]}"
 
-    buildkite-agent artifact download "${args[@]}" "$(IFS=, ; echo "${paths[*]}")" "${workdir}"
+    buildkite-agent artifact download "${args[@]}" "${paths[*]}" "${workdir}"
   else
     echo "--- Downloading artifacts"
 
-    buildkite-agent artifact download "$(IFS=, ; echo "${paths[*]}")" "${workdir}"
+    buildkite-agent artifact download "${paths[*]}" "${workdir}"
   fi
 elif [ "${#paths[@]}" -gt 1 ]; then
   if [ "${#args[@]}" -gt 0 ]; then

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -30,7 +30,7 @@ done < <(env | sort)
 
 workdir="${BUILDKITE_PLUGIN_ARTIFACTS_WORKDIR:-.}"
 
-if [ "${#paths[@]}" -gt 0 ]; then
+if [ "${#paths[@]}" -eq 1 ]; then
   if [ "${#args[@]}" -gt 0 ]; then
     echo "--- Downloading artifacts with args: ${args[*]}"
 
@@ -39,5 +39,21 @@ if [ "${#paths[@]}" -gt 0 ]; then
     echo "--- Downloading artifacts"
 
     buildkite-agent artifact download "$(IFS=, ; echo "${paths[*]}")" "${workdir}"
+  fi
+elif [ "${#paths[@]}" -gt 1 ]; then
+  if [ "${#args[@]}" -gt 0 ]; then
+    echo "--- Downloading artifacts with args: ${args[*]}"
+
+    for path in "${paths[@]}"
+      do
+        buildkite-agent artifact download "${args[@]}" "$path" "${workdir}"
+      done
+  else
+    echo "--- Downloading artifacts"
+
+    for path in "${paths[@]}"
+      do
+        buildkite-agent artifact download "$path" "${workdir}"
+      done
   fi
 fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,9 +5,9 @@ requirements: []
 configuration:
   properties:
     upload:
-      type: string
+      type: [ string, array ]
     download:
-      type: string
+      type: [ string, array ]
     step:
       type: string
     build:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -73,7 +73,7 @@ load '/usr/local/lib/bats/load.bash'
 @test "Pre-command downloads multiple artifacts with build" {
   stub buildkite-agent \
     "artifact download --build 12345 foo.log . : echo Downloading artifacts with args: --build 12345" \
-    "artifact download --build 12345 bar.log . : echo Downloading artifacts with args: --build 12345" \
+    "artifact download --build 12345 bar.log . : echo Downloading artifacts with args: --build 12345"
 
   export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0="foo.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1="bar.log"
@@ -81,7 +81,7 @@ load '/usr/local/lib/bats/load.bash'
   run "$PWD/hooks/pre-command"
 
   assert_success
-  assert_output --partial "Downloading artifacts"
+  assert_output --partial "Downloading artifacts with args: --build 12345"
 
   unstub buildkite-agent
   unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD
@@ -107,6 +107,43 @@ load '/usr/local/lib/bats/load.bash'
     "artifact upload --job 12345 *.log : echo Uploading artifacts with args: --job 12345"
 
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_JOB="12345"
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Uploading artifacts with args: --job 12345"
+
+  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_JOB
+}
+
+@test "Post-command uploads multiple artifacts" {
+  stub buildkite-agent \
+    "artifact upload foo.log : echo Uploading artifacts" \
+    "artifact upload bar.log : echo Uploading artifacts" \
+    "artifact upload baz.log : echo Uploading artifacts" \
+
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0="foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1="bar.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2="baz.log"
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Uploading artifacts"
+
+  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_JOB
+}
+
+@test "Post-command uploads multiple artifacts with a job" {
+  stub buildkite-agent \
+    "artifact upload --job 12345 foo.log : echo Uploading artifacts with args: --job 12345" \
+    "artifact upload --job 12345 bar.log : echo Uploading artifacts with args: --job 12345"
+
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0="foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1="bar.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_JOB="12345"
   run "$PWD/hooks/post-command"
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -66,8 +66,9 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Downloading artifacts"
 
   unstub buildkite-agent
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD
-  unset BUILDKITE_PLUGIN_ARTIFACTS_BUILD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2
 }
 
 @test "Pre-command downloads multiple artifacts with build" {
@@ -84,7 +85,8 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Downloading artifacts with args: --build 12345"
 
   unstub buildkite-agent
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1
   unset BUILDKITE_PLUGIN_ARTIFACTS_BUILD
 }
 
@@ -133,8 +135,9 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Uploading artifacts"
 
   unstub buildkite-agent
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
-  unset BUILDKITE_PLUGIN_ARTIFACTS_JOB
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2
 }
 
 @test "Post-command uploads multiple artifacts with a job" {
@@ -151,6 +154,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Uploading artifacts with args: --job 12345"
 
   unstub buildkite-agent
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1
   unset BUILDKITE_PLUGIN_ARTIFACTS_JOB
 }

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -51,6 +51,43 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_ARTIFACTS_BUILD
 }
 
+@test "Pre-command downloads multiple artifacts" {
+  stub buildkite-agent \
+    "artifact download foo.log . : echo Downloading artifacts" \
+    "artifact download bar.log . : echo Downloading artifacts" \
+    "artifact download baz.log . : echo Downloading artifacts"
+
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0="foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1="bar.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2="baz.log"
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts"
+
+  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_BUILD
+}
+
+@test "Pre-command downloads multiple artifacts with build" {
+  stub buildkite-agent \
+    "artifact download --build 12345 foo.log . : echo Downloading artifacts with args: --build 12345" \
+    "artifact download --build 12345 bar.log . : echo Downloading artifacts with args: --build 12345" \
+
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0="foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1="bar.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_BUILD="12345"
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts"
+
+  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_BUILD
+}
+
 @test "Post-command uploads artifacts with a single value for upload" {
   stub buildkite-agent \
     "artifact upload *.log : echo Uploading artifacts"


### PR DESCRIPTION
using
```yml
download: ["bar.zip", "foo.zip"]
```
I was getting errors finding artifact "bar.zip,foo.zip".

I didn't see a way for buildkite-agent artifact download command to take multiple arguments other than calling it multiple times.

