### PR TITLE
Use non-expanding headers 

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ "${BUILDKITE_PLUGIN_ARTIFACTS_DEBUG:-false}" =~ (true|on|1) ]] ; then
-  echo "--- :hammer: Enabling debug mode"
+  echo "~~~ :hammer: Enabling debug mode"
   set -x
 fi
 
@@ -31,24 +31,24 @@ trap popd EXIT
 
 if [ "${#paths[@]}" -eq 1 ]; then
   if [ "${#args[@]}" -gt 0 ]; then
-    echo "--- Uploading artifacts with args: ${args[*]}"
+    echo "~~~ Uploading artifacts with args: ${args[*]}"
 
     buildkite-agent artifact upload "${args[@]}" "${paths[*]}"
   else
-    echo "--- Uploading artifacts"
+    echo "~~~ Uploading artifacts"
 
     buildkite-agent artifact upload "${paths[*]}"
   fi
 elif [ "${#paths[@]}" -gt 1 ]; then
   if [ "${#args[@]}" -gt 0 ]; then
-    echo "--- Uploading artifacts with args: ${args[*]}"
+    echo "~~~ Uploading artifacts with args: ${args[*]}"
 
     for path in "${paths[@]}"
       do
         buildkite-agent artifact upload "${args[@]}" "$path"
       done
   else
-    echo "--- Uploading artifacts"
+    echo "~~~ Uploading artifacts"
 
     for path in "${paths[@]}"
       do


### PR DESCRIPTION
Use `~~~` headers to prevent them expanding when something else fails in a job.