### PR TITLE
Fix the plugin schema to match the new from/to object syntax

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -4,11 +4,38 @@ author: https://github.com/buildkite
 requirements:
   - bash
 configuration:
+  definitions:
+    from-to-object:
+      type: object
+      properties:
+        from:
+          type: string
+        to:
+          type: string
+      required:
+        - from
+        - to
   properties:
     upload:
-      type: [ string, array ]
+      oneOf:
+        - $ref: '#/definitions/from-to-object'
+        - type: string
+        - type: array
+          items:
+            type: string
+        - type: array
+          items:
+            $ref: '#/definitions/from-to-object'
     download:
-      type: [ string, array ]
+      oneOf:
+        - $ref: '#/definitions/from-to-object'
+        - type: string
+        - type: array
+          items:
+            type: string
+        - type: array
+          items:
+            $ref: '#/definitions/from-to-object'
     step:
       type: string
     build:


### PR DESCRIPTION
In #27 the plugin.yml hadn't been updated with the new support, which breaks the plugin lint step. This updates the schema to support the newly supported param syntax, and fixes the plugin lint step.