### PR TITLE
Support for user-defined upload ACL when using S3 or GS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,31 @@ steps:
           to: log2.log
 ```
 
+### User-defined ACL on uploaded files
+When using AWS S3 or Google Cloud Storage as your artifact store, you can optionally define an object-level ACL for your uploaded artifacts. This allows you to have granular control over which artifacts are made public or private.
+
+If not specified it will respect the relevant setting at the agent level.
+
+eg: uploading a public file when using S3
+```yml
+steps:
+  - command: ...
+    plugins:
+    - artifacts#v1.3.0:
+        upload: "coverage-report/**/*"
+        s3-upload-acl: public-read
+```
+
+eg: uploading a private file when using GS
+```yml
+steps:
+  - command: ...
+    plugins:
+    - artifacts#v1.3.0:
+        upload: "coverage-report/**/*"
+        gs-upload-acl: private
+```
+
 ## Downloading artifacts
 
 This downloads artifacts matching globs to the local filesystem. See [downloading artifacts](https://buildkite.com/docs/agent/cli-artifact#downloading-artifacts) for more details.

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -40,6 +40,19 @@ workdir=${BUILDKITE_PLUGIN_ARTIFACTS_WORKDIR:-.}
 pushd "${workdir}"
 trap popd EXIT
 
+
+# Set user-provided object ACL for AWS S3
+if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_S3_UPLOAD_ACL:-}" ]] ; then
+  echo "~~~ Setting S3 object upload ACL: ${BUILDKITE_PLUGIN_ARTIFACTS_S3_UPLOAD_ACL}"
+  export BUILDKITE_S3_ACL="${BUILDKITE_PLUGIN_ARTIFACTS_S3_UPLOAD_ACL}"
+fi
+
+# Set user-provided object ACL for Google Cloud Storage
+if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_GS_UPLOAD_ACL:-}" ]] ; then
+  echo "~~~ Setting GS object upload ACL: ${BUILDKITE_PLUGIN_ARTIFACTS_GS_UPLOAD_ACL}"
+  export BUILDKITE_GS_ACL="${BUILDKITE_PLUGIN_ARTIFACTS_GS_UPLOAD_ACL}"
+fi
+
 if [[ "${SINGULAR_UPLOAD_OBJECT}" == "true" ]]; then
   if [[ "${RELOCATION}" == "true" ]]; then
     if [[ -e "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM:-}" ]]; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -40,6 +40,11 @@ configuration:
       type: string
     build:
       type: string
+    s3-upload-acl:
+      type: string
+    gs-upload-acl:
+      type: string
+
   oneOf:
     - required:
       - upload

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -342,5 +342,5 @@ load '/usr/local/lib/bats/load.bash'
 
   unstub buildkite-agent
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
-  unset BUILDKITE_PLUGIN_ARTIFACTS_S3_UPLOAD_ACL
+  unset BUILDKITE_PLUGIN_ARTIFACTS_GS_UPLOAD_ACL
 }

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -312,3 +312,35 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1
   unset BUILDKITE_PLUGIN_ARTIFACTS_JOB
 }
+
+@test "Post-command upload with user-provided S3 object ACL" {
+  stub buildkite-agent \
+    "artifact upload *.log : echo Uploading artifacts"
+
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_S3_UPLOAD_ACL="bucket-owner-read"
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Setting S3 object upload ACL: bucket-owner-read"
+
+  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_S3_UPLOAD_ACL
+}
+
+@test "Post-command upload with user-provided GS object ACL" {
+  stub buildkite-agent \
+    "artifact upload *.log : echo Uploading artifacts"
+
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_GS_UPLOAD_ACL="bucketOwnerRead"
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Setting GS object upload ACL: bucketOwnerRead"
+
+  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_S3_UPLOAD_ACL
+}


### PR DESCRIPTION
This PR introduces support for setting the ACL on uploaded files when the artifacts are stored on customer-managed S3 or GS buckets as [per documentation](https://buildkite.com/docs/agent/v3/cli-artifact#using-your-private-aws-s3-bucket)

