### PR TITLE
don't fail on download if no artifacts are found

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -51,11 +51,11 @@ if [[ "${SINGULAR_DOWNLOAD_OBJECT}" == "true" ]]; then
   if [[ "${#args[@]}" -gt 0 ]]; then
     echo "~~~ Downloading artifacts with args: ${args[*]}"
     status=$(buildkite-agent artifact download "${args[@]}" "${source}" "${workdir}" 2>&1 || true)
-    echo $status
+    echo "$status"
   else
     echo "~~~ Downloading artifacts"
     status=$(buildkite-agent artifact download "${source}" "${workdir}" 2>&1 || true)
-    echo $status
+    echo "$status"
   fi
   if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO:-}" ]]; then
     if ! [[ -d $(dirname "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO}") ]]; then
@@ -78,7 +78,7 @@ elif [[ "${MULTIPLE_DOWNLOADS}" == "true" ]]; then
           source="${path}"
         fi
         status=$(buildkite-agent artifact download "${args[@]}" "${source}" "${workdir}" 2>&1 || true)
-        echo $status
+        echo "$status"
         if [[ -n "${!dest_env_var:-}" ]]; then
           if ! [[ -d $(dirname "${!dest_env_var}") ]]; then
             mkdir -p "$(dirname "${!dest_env_var}")"
@@ -101,7 +101,7 @@ elif [[ "${MULTIPLE_DOWNLOADS}" == "true" ]]; then
           source="${path}"
         fi
         status=$(buildkite-agent artifact download "${source}" "${workdir}" 2>&1 || true)
-        echo $status
+        echo "$status"
         if [[ -n "${!dest_env_var:-}" ]]; then
           if ! [[ -d $(dirname "${!dest_env_var}") ]]; then
             mkdir -p "$(dirname "${!dest_env_var}")"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -50,10 +50,12 @@ if [[ "${SINGULAR_DOWNLOAD_OBJECT}" == "true" ]]; then
 
   if [[ "${#args[@]}" -gt 0 ]]; then
     echo "~~~ Downloading artifacts with args: ${args[*]}"
-    buildkite-agent artifact download "${args[@]}" "${source}" "${workdir}"
+    status=$(buildkite-agent artifact download "${args[@]}" "${source}" "${workdir}" 2>&1 || true)
+    echo $status
   else
     echo "~~~ Downloading artifacts"
-    buildkite-agent artifact download "${source}" "${workdir}"
+    status=$(buildkite-agent artifact download "${source}" "${workdir}" 2>&1 || true)
+    echo $status
   fi
   if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO:-}" ]]; then
     if ! [[ -d $(dirname "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO}") ]]; then
@@ -75,7 +77,8 @@ elif [[ "${MULTIPLE_DOWNLOADS}" == "true" ]]; then
         else
           source="${path}"
         fi
-        buildkite-agent artifact download "${args[@]}" "${source}" "${workdir}"
+        status=$(buildkite-agent artifact download "${args[@]}" "${source}" "${workdir}" 2>&1 || true)
+        echo $status
         if [[ -n "${!dest_env_var:-}" ]]; then
           if ! [[ -d $(dirname "${!dest_env_var}") ]]; then
             mkdir -p "$(dirname "${!dest_env_var}")"
@@ -97,7 +100,8 @@ elif [[ "${MULTIPLE_DOWNLOADS}" == "true" ]]; then
         else
           source="${path}"
         fi
-        buildkite-agent artifact download "${source}" "${workdir}"
+        status=$(buildkite-agent artifact download "${source}" "${workdir}" 2>&1 || true)
+        echo $status
         if [[ -n "${!dest_env_var:-}" ]]; then
           if ! [[ -d $(dirname "${!dest_env_var}") ]]; then
             mkdir -p "$(dirname "${!dest_env_var}")"


### PR DESCRIPTION
this will capture the response but not fail the step if there are no artifacts found.  fixes https://github.com/buildkite-plugins/artifacts-buildkite-plugin/issues/56

before this change my pipeline step would exit and not run the additional plugins and commands in the same step with:
```
2021-10-07 17:43:28 INFO   Searching for artifacts: "*"
--
  | 2021-10-07 17:43:29 FATAL  Failed to download artifacts: No artifacts found for downloading
  | 🚨 Error: The plugin artifacts pre-command hook exited with status 1
```
with this change the error is caught but the step can continue:
```
2021-10-07 17:58:08 INFO  Searching for artifacts: "*" 2021-10-07 17:58:08 FATAL  Failed to download artifacts: No artifacts found for downloading
```
