### PR TITLE
Support more than 10 artifacts

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -29,7 +29,7 @@ if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD:-}" ]] || { [[ -n "${BUILDKITE_PLU
 fi
 
 while IFS='=' read -r path _ ; do
-  if [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]+) ]] && ! [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]_TO+) ]]; then
+  if [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]+) ]] && ! [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]+_TO) ]]; then
     MULTIPLE_UPLOADS="true"
     paths+=("${!path}")
   fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -33,7 +33,7 @@ if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD:-}" ]] || { [[ -n "${BUILDKITE_P
 fi
 
 while IFS='=' read -r path _ ; do
-  if [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+) ]] && ! [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]_TO+) ]]; then
+  if [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+) ]] && ! [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+_TO) ]]; then
     MULTIPLE_DOWNLOADS="true"
     paths+=("${!path}")
   fi

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -179,6 +179,108 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_ARTIFACTS_BUILD
 }
 
+@test "Pre-command downloads multiple > 10 artifacts with build and relocation" {
+  touch /tmp/foo-0.log
+  touch /tmp/foo-1.log
+  touch /tmp/foo-2.log
+  touch /tmp/foo-3.log
+  touch /tmp/foo-4.log
+  touch /tmp/foo-5.log
+  touch /tmp/foo-6.log
+  touch /tmp/foo-7.log
+  touch /tmp/foo-8.log
+  touch /tmp/foo-9.log
+  touch /tmp/foo-10.log
+
+  stub buildkite-agent \
+    "artifact download --build 12345 /tmp/foo-0.log : echo Downloading artifacts with args: --build 12345" \
+    "artifact download --build 12345 /tmp/foo-1.log : echo Downloading artifacts with args: --build 12345" \
+    "artifact download --build 12345 /tmp/foo-2.log : echo Downloading artifacts with args: --build 12345" \
+    "artifact download --build 12345 /tmp/foo-3.log : echo Downloading artifacts with args: --build 12345" \
+    "artifact download --build 12345 /tmp/foo-4.log : echo Downloading artifacts with args: --build 12345" \
+    "artifact download --build 12345 /tmp/foo-5.log : echo Downloading artifacts with args: --build 12345" \
+    "artifact download --build 12345 /tmp/foo-6.log : echo Downloading artifacts with args: --build 12345" \
+    "artifact download --build 12345 /tmp/foo-7.log : echo Downloading artifacts with args: --build 12345" \
+    "artifact download --build 12345 /tmp/foo-8.log : echo Downloading artifacts with args: --build 12345" \
+    "artifact download --build 12345 /tmp/foo-9.log : echo Downloading artifacts with args: --build 12345" \
+    "artifact download --build 12345 /tmp/foo-10.log : echo Downloading artifacts with args: --build 12345"
+
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_FROM="/tmp/foo-0.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_TO="/tmp/foo-r-0.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1_FROM="/tmp/foo-1.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1_TO="/tmp/foo-r-1.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2_FROM="/tmp/foo-2.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2_TO="/tmp/foo-r-2.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_3_FROM="/tmp/foo-3.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_3_TO="/tmp/foo-r-3.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_4_FROM="/tmp/foo-4.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_4_TO="/tmp/foo-r-4.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_5_FROM="/tmp/foo-5.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_5_TO="/tmp/foo-r-5.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_6_FROM="/tmp/foo-6.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_6_TO="/tmp/foo-r-6.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_7_FROM="/tmp/foo-7.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_7_TO="/tmp/foo-r-7.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_8_FROM="/tmp/foo-8.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_8_TO="/tmp/foo-r-8.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_9_FROM="/tmp/foo-9.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_9_TO="/tmp/foo-r-9.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_10_FROM="/tmp/foo-10.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_10_TO="/tmp/foo-r-10.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_BUILD="12345"
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts with args: --build 12345"
+  assert [ -e /tmp/foo-r-0.log ]
+  assert [ ! -e /tmp/foo-0.log ]
+  assert [ -e /tmp/foo-r-1.log ]
+  assert [ ! -e /tmp/foo-1.log ]
+  assert [ -e /tmp/foo-r-2.log ]
+  assert [ ! -e /tmp/foo-2.log ]
+  assert [ -e /tmp/foo-r-3.log ]
+  assert [ ! -e /tmp/foo-3.log ]
+  assert [ -e /tmp/foo-r-4.log ]
+  assert [ ! -e /tmp/foo-4.log ]
+  assert [ -e /tmp/foo-r-5.log ]
+  assert [ ! -e /tmp/foo-5.log ]
+  assert [ -e /tmp/foo-r-6.log ]
+  assert [ ! -e /tmp/foo-6.log ]
+  assert [ -e /tmp/foo-r-7.log ]
+  assert [ ! -e /tmp/foo-7.log ]
+  assert [ -e /tmp/foo-r-8.log ]
+  assert [ ! -e /tmp/foo-8.log ]
+  assert [ -e /tmp/foo-r-9.log ]
+  assert [ ! -e /tmp/foo-9.log ]
+  assert [ -e /tmp/foo-r-10.log ]
+  assert [ ! -e /tmp/foo-10.log ]
+
+  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_3_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_3_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_4_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_4_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_5_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_5_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_6_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_6_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_7_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_7_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_8_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_8_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_9_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_9_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_10_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_10_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_BUILD
+}
+
 @test "Post-command uploads artifacts with a single value for upload" {
   stub buildkite-agent \
     "artifact upload *.log : echo Uploading artifacts"
@@ -292,6 +394,107 @@ load '/usr/local/lib/bats/load.bash'
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_TO
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2
+}
+
+@test "Post-command uploads multiple > 10 artifacts with relocation" {
+  touch /tmp/foo-0.log
+  touch /tmp/foo-1.log
+  touch /tmp/foo-2.log
+  touch /tmp/foo-3.log
+  touch /tmp/foo-4.log
+  touch /tmp/foo-5.log
+  touch /tmp/foo-6.log
+  touch /tmp/foo-7.log
+  touch /tmp/foo-8.log
+  touch /tmp/foo-9.log
+  touch /tmp/foo-10.log
+
+  stub buildkite-agent \
+    "artifact upload /tmp/foo-r-0.log : echo Uploading artifact" \
+    "artifact upload /tmp/foo-r-1.log : echo Uploading artifact" \
+    "artifact upload /tmp/foo-r-2.log : echo Uploading artifact" \
+    "artifact upload /tmp/foo-r-3.log : echo Uploading artifact" \
+    "artifact upload /tmp/foo-r-4.log : echo Uploading artifact" \
+    "artifact upload /tmp/foo-r-5.log : echo Uploading artifact" \
+    "artifact upload /tmp/foo-r-6.log : echo Uploading artifact" \
+    "artifact upload /tmp/foo-r-7.log : echo Uploading artifact" \
+    "artifact upload /tmp/foo-r-8.log : echo Uploading artifact" \
+    "artifact upload /tmp/foo-r-9.log : echo Uploading artifact" \
+    "artifact upload /tmp/foo-r-10.log : echo Uploading artifact"
+
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_FROM="/tmp/foo-0.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_TO="/tmp/foo-r-0.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1_FROM="/tmp/foo-1.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1_TO="/tmp/foo-r-1.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2_FROM="/tmp/foo-2.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2_TO="/tmp/foo-r-2.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_3_FROM="/tmp/foo-3.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_3_TO="/tmp/foo-r-3.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_4_FROM="/tmp/foo-4.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_4_TO="/tmp/foo-r-4.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_5_FROM="/tmp/foo-5.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_5_TO="/tmp/foo-r-5.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_6_FROM="/tmp/foo-6.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_6_TO="/tmp/foo-r-6.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_7_FROM="/tmp/foo-7.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_7_TO="/tmp/foo-r-7.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_8_FROM="/tmp/foo-8.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_8_TO="/tmp/foo-r-8.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_9_FROM="/tmp/foo-9.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_9_TO="/tmp/foo-r-9.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_10_FROM="/tmp/foo-10.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_10_TO="/tmp/foo-r-10.log"
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Uploading artifacts"
+  assert [ -e /tmp/foo-r-0.log ]
+  assert [ ! -e /tmp/foo-0.log ]
+  assert [ -e /tmp/foo-r-1.log ]
+  assert [ ! -e /tmp/foo-1.log ]
+  assert [ -e /tmp/foo-r-2.log ]
+  assert [ ! -e /tmp/foo-2.log ]
+  assert [ -e /tmp/foo-r-3.log ]
+  assert [ ! -e /tmp/foo-3.log ]
+  assert [ -e /tmp/foo-r-4.log ]
+  assert [ ! -e /tmp/foo-4.log ]
+  assert [ -e /tmp/foo-r-5.log ]
+  assert [ ! -e /tmp/foo-5.log ]
+  assert [ -e /tmp/foo-r-6.log ]
+  assert [ ! -e /tmp/foo-6.log ]
+  assert [ -e /tmp/foo-r-7.log ]
+  assert [ ! -e /tmp/foo-7.log ]
+  assert [ -e /tmp/foo-r-8.log ]
+  assert [ ! -e /tmp/foo-8.log ]
+  assert [ -e /tmp/foo-r-9.log ]
+  assert [ ! -e /tmp/foo-9.log ]
+  assert [ -e /tmp/foo-r-10.log ]
+  assert [ ! -e /tmp/foo-10.log ]
+
+  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_3_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_3_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_4_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_4_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_5_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_5_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_6_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_6_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_7_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_7_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_8_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_8_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_9_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_9_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_10_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_10_TO
 }
 
 @test "Post-command uploads multiple artifacts with a job" {

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -180,105 +180,28 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Pre-command downloads multiple > 10 artifacts with build and relocation" {
-  touch /tmp/foo-0.log
-  touch /tmp/foo-1.log
-  touch /tmp/foo-2.log
-  touch /tmp/foo-3.log
-  touch /tmp/foo-4.log
-  touch /tmp/foo-5.log
-  touch /tmp/foo-6.log
-  touch /tmp/foo-7.log
-  touch /tmp/foo-8.log
-  touch /tmp/foo-9.log
-  touch /tmp/foo-10.log
-
-  stub buildkite-agent \
-    "artifact download --build 12345 /tmp/foo-0.log : echo Downloading artifacts with args: --build 12345" \
-    "artifact download --build 12345 /tmp/foo-1.log : echo Downloading artifacts with args: --build 12345" \
-    "artifact download --build 12345 /tmp/foo-2.log : echo Downloading artifacts with args: --build 12345" \
-    "artifact download --build 12345 /tmp/foo-3.log : echo Downloading artifacts with args: --build 12345" \
-    "artifact download --build 12345 /tmp/foo-4.log : echo Downloading artifacts with args: --build 12345" \
-    "artifact download --build 12345 /tmp/foo-5.log : echo Downloading artifacts with args: --build 12345" \
-    "artifact download --build 12345 /tmp/foo-6.log : echo Downloading artifacts with args: --build 12345" \
-    "artifact download --build 12345 /tmp/foo-7.log : echo Downloading artifacts with args: --build 12345" \
-    "artifact download --build 12345 /tmp/foo-8.log : echo Downloading artifacts with args: --build 12345" \
-    "artifact download --build 12345 /tmp/foo-9.log : echo Downloading artifacts with args: --build 12345" \
-    "artifact download --build 12345 /tmp/foo-10.log : echo Downloading artifacts with args: --build 12345"
-
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_FROM="/tmp/foo-0.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_TO="/tmp/foo-r-0.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1_FROM="/tmp/foo-1.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1_TO="/tmp/foo-r-1.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2_FROM="/tmp/foo-2.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2_TO="/tmp/foo-r-2.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_3_FROM="/tmp/foo-3.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_3_TO="/tmp/foo-r-3.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_4_FROM="/tmp/foo-4.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_4_TO="/tmp/foo-r-4.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_5_FROM="/tmp/foo-5.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_5_TO="/tmp/foo-r-5.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_6_FROM="/tmp/foo-6.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_6_TO="/tmp/foo-r-6.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_7_FROM="/tmp/foo-7.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_7_TO="/tmp/foo-r-7.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_8_FROM="/tmp/foo-8.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_8_TO="/tmp/foo-r-8.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_9_FROM="/tmp/foo-9.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_9_TO="/tmp/foo-r-9.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_10_FROM="/tmp/foo-10.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_10_TO="/tmp/foo-r-10.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_BUILD="12345"
+  stub_calls=()
+  for i in $(seq 0 10); do
+    touch "/tmp/foo-$i.log"
+    export "BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${i}_FROM=/tmp/foo-${i}.log"
+    export "BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${i}_TO=/tmp/foo-r-${i}.log"
+    stub_calls+=( "artifact download --build 12345 /tmp/foo-$i.log : echo Downloading artifacts with args: --build 12345" )
+  done
+  stub buildkite-agent "${stub_calls[@]}"
+
   run "$PWD/hooks/pre-command"
 
   assert_success
   assert_output --partial "Downloading artifacts with args: --build 12345"
-  assert [ -e /tmp/foo-r-0.log ]
-  assert [ ! -e /tmp/foo-0.log ]
-  assert [ -e /tmp/foo-r-1.log ]
-  assert [ ! -e /tmp/foo-1.log ]
-  assert [ -e /tmp/foo-r-2.log ]
-  assert [ ! -e /tmp/foo-2.log ]
-  assert [ -e /tmp/foo-r-3.log ]
-  assert [ ! -e /tmp/foo-3.log ]
-  assert [ -e /tmp/foo-r-4.log ]
-  assert [ ! -e /tmp/foo-4.log ]
-  assert [ -e /tmp/foo-r-5.log ]
-  assert [ ! -e /tmp/foo-5.log ]
-  assert [ -e /tmp/foo-r-6.log ]
-  assert [ ! -e /tmp/foo-6.log ]
-  assert [ -e /tmp/foo-r-7.log ]
-  assert [ ! -e /tmp/foo-7.log ]
-  assert [ -e /tmp/foo-r-8.log ]
-  assert [ ! -e /tmp/foo-8.log ]
-  assert [ -e /tmp/foo-r-9.log ]
-  assert [ ! -e /tmp/foo-9.log ]
-  assert [ -e /tmp/foo-r-10.log ]
-  assert [ ! -e /tmp/foo-10.log ]
-
-  unstub buildkite-agent
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_3_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_3_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_4_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_4_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_5_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_5_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_6_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_6_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_7_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_7_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_8_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_8_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_9_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_9_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_10_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_10_TO
+  for i in $(seq 0 10); do
+    assert [ -e /tmp/foo-r-"${i}".log ]
+    assert [ ! -e /tmp/foo-"${i}".log ]
+    unset "BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${i}_FROM"
+    unset "BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${i}_TO"
+  done
   unset BUILDKITE_PLUGIN_ARTIFACTS_BUILD
+  unstub buildkite-agent
 }
 
 @test "Post-command uploads artifacts with a single value for upload" {
@@ -397,104 +320,26 @@ load '/usr/local/lib/bats/load.bash'
 }
 
 @test "Post-command uploads multiple > 10 artifacts with relocation" {
-  touch /tmp/foo-0.log
-  touch /tmp/foo-1.log
-  touch /tmp/foo-2.log
-  touch /tmp/foo-3.log
-  touch /tmp/foo-4.log
-  touch /tmp/foo-5.log
-  touch /tmp/foo-6.log
-  touch /tmp/foo-7.log
-  touch /tmp/foo-8.log
-  touch /tmp/foo-9.log
-  touch /tmp/foo-10.log
-
-  stub buildkite-agent \
-    "artifact upload /tmp/foo-r-0.log : echo Uploading artifact" \
-    "artifact upload /tmp/foo-r-1.log : echo Uploading artifact" \
-    "artifact upload /tmp/foo-r-2.log : echo Uploading artifact" \
-    "artifact upload /tmp/foo-r-3.log : echo Uploading artifact" \
-    "artifact upload /tmp/foo-r-4.log : echo Uploading artifact" \
-    "artifact upload /tmp/foo-r-5.log : echo Uploading artifact" \
-    "artifact upload /tmp/foo-r-6.log : echo Uploading artifact" \
-    "artifact upload /tmp/foo-r-7.log : echo Uploading artifact" \
-    "artifact upload /tmp/foo-r-8.log : echo Uploading artifact" \
-    "artifact upload /tmp/foo-r-9.log : echo Uploading artifact" \
-    "artifact upload /tmp/foo-r-10.log : echo Uploading artifact"
-
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_FROM="/tmp/foo-0.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_TO="/tmp/foo-r-0.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1_FROM="/tmp/foo-1.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1_TO="/tmp/foo-r-1.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2_FROM="/tmp/foo-2.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2_TO="/tmp/foo-r-2.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_3_FROM="/tmp/foo-3.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_3_TO="/tmp/foo-r-3.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_4_FROM="/tmp/foo-4.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_4_TO="/tmp/foo-r-4.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_5_FROM="/tmp/foo-5.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_5_TO="/tmp/foo-r-5.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_6_FROM="/tmp/foo-6.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_6_TO="/tmp/foo-r-6.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_7_FROM="/tmp/foo-7.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_7_TO="/tmp/foo-r-7.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_8_FROM="/tmp/foo-8.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_8_TO="/tmp/foo-r-8.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_9_FROM="/tmp/foo-9.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_9_TO="/tmp/foo-r-9.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_10_FROM="/tmp/foo-10.log"
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_10_TO="/tmp/foo-r-10.log"
+  stub_calls=()
+  for i in $(seq 0 10); do
+    touch "/tmp/foo-${i}.log"
+    export "BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_${i}_FROM=/tmp/foo-${i}.log"
+    export "BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_${i}_TO=/tmp/foo-r-${i}.log"
+    stub_calls+=( "artifact upload /tmp/foo-r-$i.log : echo Uploading artifact" )
+  done
+  stub buildkite-agent "${stub_calls[@]}"
 
   run "$PWD/hooks/post-command"
 
   assert_success
   assert_output --partial "Uploading artifacts"
-  assert [ -e /tmp/foo-r-0.log ]
-  assert [ ! -e /tmp/foo-0.log ]
-  assert [ -e /tmp/foo-r-1.log ]
-  assert [ ! -e /tmp/foo-1.log ]
-  assert [ -e /tmp/foo-r-2.log ]
-  assert [ ! -e /tmp/foo-2.log ]
-  assert [ -e /tmp/foo-r-3.log ]
-  assert [ ! -e /tmp/foo-3.log ]
-  assert [ -e /tmp/foo-r-4.log ]
-  assert [ ! -e /tmp/foo-4.log ]
-  assert [ -e /tmp/foo-r-5.log ]
-  assert [ ! -e /tmp/foo-5.log ]
-  assert [ -e /tmp/foo-r-6.log ]
-  assert [ ! -e /tmp/foo-6.log ]
-  assert [ -e /tmp/foo-r-7.log ]
-  assert [ ! -e /tmp/foo-7.log ]
-  assert [ -e /tmp/foo-r-8.log ]
-  assert [ ! -e /tmp/foo-8.log ]
-  assert [ -e /tmp/foo-r-9.log ]
-  assert [ ! -e /tmp/foo-9.log ]
-  assert [ -e /tmp/foo-r-10.log ]
-  assert [ ! -e /tmp/foo-10.log ]
-
+  for i in $(seq 0 10); do
+    assert [ -e /tmp/foo-r-"${i}".log ]
+    assert [ ! -e /tmp/foo-"${i}".log ]
+    unset "BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_${i}_FROM"
+    unset "BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_${i}_TO"
+  done
   unstub buildkite-agent
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_3_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_3_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_4_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_4_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_5_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_5_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_6_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_6_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_7_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_7_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_8_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_8_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_9_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_9_TO
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_10_FROM
-  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_10_TO
 }
 
 @test "Post-command uploads multiple artifacts with a job" {


### PR DESCRIPTION
# Summary

In the Artifacts plugin, there are two broken regexs:
```sh
if [[ ... ]] && ! [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]_TO+) ]]; then
```
```sh
if [[ ... ]] && ! [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]_TO+) ]]; then
```

The pattern matching of `_[0-9]_TO+` is not catering for greater than 10 artifacts, instead it is matching strings such as `_1_TOO`.

| Before | After |
| --- | --- |
| `^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]_TO+)` | `^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]+_TO)` |
| ![image](https://user-images.githubusercontent.com/316931/142357035-6384be51-65c7-4cdd-97f0-d89d89e67616.png) | ![image](https://user-images.githubusercontent.com/316931/142356979-9ab8483a-3268-4ff2-820a-489a36d408f2.png) |


I've also added some tests, that do fail, when the pattern is incorrect. 
