### PR TITLE
Support compression of artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,35 @@ The job UUID or name to download the artifact from.
 
 The build UUID to download the artifact from.
 
+### `compressed` (optional, string)
+
+Limitations:
+* filename needs to end with `.zip` or `.tgz` and that will determine the compression executable to use
+* can not be used with `from`/`to` upload or download options
+
+When uploading, globs specified in the `upload` option will be compressed in a single file with this name and uploaded as a single artifact. The following example will get all files matching `log/**.*.log`, zip them up and upload a single artifact file named `logs.zip`:
+
+```yml
+steps:
+  - command: ...
+    plugins:
+    - artifacts#v1.5.0:
+        upload: "log/**/*.log"
+        compressed: logs.zip
+```
+
+When downloading, this option states the actual name of the artifact to be downloaded and globs in the `download` option will be extracted off of it. The following example will download the `logs.tgz` artifact and extract all files in it matching `logs/**/*.log`:
+
+```yml
+steps:
+  - command: ...
+    plugins:
+      - artifacts#v1.5.0:
+          download: "log/**/*.log"
+          compressed: logs.tgz
+```
+
+
 ### Relocation
 
 If a file needs to be renamed or moved before upload or after download, a nested object is used with `to` and `from` keys.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ The build UUID to download the artifact from.
 
 Limitations:
 * filename needs to end with `.zip` or `.tgz` and that will determine the compression executable to use
-* can not be used with `from`/`to` upload or download options
 
 When uploading, globs specified in the `upload` option will be compressed in a single file with this name and uploaded as a single artifact. The following example will get all files matching `log/**.*.log`, zip them up and upload a single artifact file named `logs.zip`:
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -111,7 +111,7 @@ elif [[ "${COMPRESSED}" == "true" ]]; then
     ((index+=1))
   done
 
-  echo "~~~ Compressing ${final_paths[@]} to ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
+  echo "~~~ Compressing ${final_paths[*]} to ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
   "${compress[@]}" "${final_paths[@]}"
 
   echo "~~~ Uploading artifacts ${EXTRA_MESSAGE}"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -93,7 +93,29 @@ if [[ "${SINGULAR_UPLOAD_OBJECT}" == "true" ]]; then
 
   echo "~~~ Uploading artifacts ${EXTRA_MESSAGE}"
   buildkite-agent artifact "${args[@]}" "${path}"
+elif [[ "${COMPRESSED}" == "true" ]]; then
+  final_paths=()
+  index=0
+  for path in "${paths[@]}"; do
+    source_env_var="BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_${index}_FROM"
+    dest_env_var="BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_${index}_TO"
+    if [[ -n "${!source_env_var:-}" ]] && [[ -n "${!dest_env_var:-}" ]]; then
+      if [[ -e ${!source_env_var} ]]; then
+        echo "~~~ Moving [${!source_env_var}] to [${!dest_env_var}]..."
+        mv ${!source_env_var} ${!dest_env_var}
+      fi
+      path="${!dest_env_var}"
+    fi
 
+    final_paths+=("$path")
+    ((index+=1))
+  done
+
+  echo "~~~ Compressing ${final_paths[@]} to ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
+  "${compress[@]}" "${final_paths[@]}"
+
+  echo "~~~ Uploading artifacts ${EXTRA_MESSAGE}"
+  buildkite-agent artifact "${args[@]}" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
 elif [[ "${MULTIPLE_UPLOADS}" == "true" ]]; then
   index=0
   echo "~~~ Uploading artifacts ${EXTRA_MESSAGE}"
@@ -107,12 +129,6 @@ elif [[ "${MULTIPLE_UPLOADS}" == "true" ]]; then
         mv ${!source_env_var} ${!dest_env_var}
       fi
       path="${!dest_env_var}"
-    fi
-
-    if [[ "${COMPRESSED}" == "true" ]]; then
-      echo "~~~ Compressing ${path} to ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
-      "${compress[@]}" "${path}"
-      path=" ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
     fi
 
     buildkite-agent artifact "${args[@]}" "$path"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -26,7 +26,7 @@ if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED:-}" ]]; then
   if [[ "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" =~ .*\.zip ]]; then
     compress+=("zip" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}")
   elif [[ "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" =~ .*\.tgz ]]; then
-    compress+=("tar czf" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}")
+    compress+=("tar" "czf" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}")
   else
     echo "+++ 🚨 The inferred compression file format for the artifact is not currently supported"
     exit 1

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -13,19 +13,34 @@ if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_JOB:-}" ]] ; then
 fi
 
 paths=()
+compress=()
 
+COMPRESSED="false"
 RELOCATION="false"
 SINGULAR_UPLOAD_OBJECT="false"
 MULTIPLE_UPLOADS="false"
 
+if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED:-}" ]]; then
+  COMPRESSED="true"
+
+  if [[ "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" =~ .*\.zip ]]; then
+    compress+=("zip" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}")
+  elif [[ "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" =~ .*\.tgz ]]; then
+    compress+=("tar czf" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}")
+  else
+    echo "+++ 🚨 The inferred compression file format for the artifact is not currently supported"
+    exit 1
+  fi
+fi
+
 if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD:-}" ]] || { [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM:-}" ]] && [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_TO:-}" ]]; }; then
-    SINGULAR_UPLOAD_OBJECT="true"
-    if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD:-}" ]] ; then
-      paths+=("${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD}")
-    elif [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM:-}" ]] && [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_TO:-}" ]] ; then
-      RELOCATION="true"
-      paths+=("${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM}")
-    fi
+  SINGULAR_UPLOAD_OBJECT="true"
+  if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD:-}" ]] ; then
+    paths+=("${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD}")
+  elif [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM:-}" ]] && [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_TO:-}" ]] ; then
+    RELOCATION="true"
+    paths+=("${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM}")
+  fi
 fi
 
 while IFS='=' read -r path _ ; do
@@ -70,6 +85,12 @@ if [[ "${SINGULAR_UPLOAD_OBJECT}" == "true" ]]; then
     path="${paths[0]}"
   fi
 
+  if [[ "${COMPRESSED}" == "true" ]]; then
+    echo "~~~ Compressing ${path} to ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
+    "${compress[@]}" "${path}"
+    path=" ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
+  fi
+
   echo "~~~ Uploading artifacts ${EXTRA_MESSAGE}"
   buildkite-agent artifact "${args[@]}" "${path}"
 
@@ -87,6 +108,13 @@ elif [[ "${MULTIPLE_UPLOADS}" == "true" ]]; then
       fi
       path="${!dest_env_var}"
     fi
+
+    if [[ "${COMPRESSED}" == "true" ]]; then
+      echo "~~~ Compressing ${path} to ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
+      "${compress[@]}" "${path}"
+      path=" ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
+    fi
+
     buildkite-agent artifact "${args[@]}" "$path"
     ((index+=1))
   done

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -69,6 +69,16 @@ if [[ "${COMPRESSED}" == "true" ]]; then
   echo "~~~ Uncompressing ${paths[@]} from ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
   "${compress[@]}" "${paths[@]}"
 
+  # single relocation
+  if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO:-}" ]]; then
+    if ! [[ -d $(dirname "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO}") ]]; then
+        mkdir -p "$(dirname "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO}")"
+    fi
+    echo "~~~ Moving [${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM}] to [${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO}]..."
+    mv "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM}" "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO}"
+  fi
+
+  # multiple relocations
   index=0
   for path in "${paths[@]}"; do
     source_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_FROM"
@@ -83,6 +93,7 @@ if [[ "${COMPRESSED}" == "true" ]]; then
  
     ((index+=1))
   done
+
 elif [[ "${SINGULAR_DOWNLOAD_OBJECT}" == "true" ]]; then
   if [[ "${RELOCATION}" == "true" ]]; then
     source="${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM}"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -66,7 +66,7 @@ if [[ "${COMPRESSED}" == "true" ]]; then
   buildkite-agent artifact "${args[@]}" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" "${workdir}"
 
 
-  echo "~~~ Uncompressing ${paths[@]} from ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
+  echo "~~~ Uncompressing ${paths[*]} from ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
   "${compress[@]}" "${paths[@]}"
 
   # single relocation

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -17,10 +17,24 @@ if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_BUILD:-}" ]] ; then
 fi
 
 paths=()
+compress=()
 
+COMPRESSED="false"
 SINGULAR_DOWNLOAD_OBJECT="false"
 RELOCATION="false"
 MULTIPLE_DOWNLOADS="false"
+
+if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED:-}" ]]; then
+  COMPRESSED="true"
+  if [[ "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" =~ .*\.zip ]]; then
+    compress+=("unzip" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}")
+  elif [[ "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" =~ .*\.tgz ]]; then
+    compress+=("tar" "xzf" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}")
+  else
+    echo "+++ 🚨 The inferred compression file format for the artifact is not currently supported"
+    exit 1
+  fi
+fi
 
 if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD:-}" ]] || { [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM:-}" ]] && [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO:-}" ]]; }; then
     SINGULAR_DOWNLOAD_OBJECT="true"
@@ -47,7 +61,29 @@ fi
 
 workdir="${BUILDKITE_PLUGIN_ARTIFACTS_WORKDIR:-.}"
 
-if [[ "${SINGULAR_DOWNLOAD_OBJECT}" == "true" ]]; then
+if [[ "${COMPRESSED}" == "true" ]]; then
+  echo "~~~ Downloading artifacts ${EXTRA_MESSAGE}"
+  buildkite-agent artifact "${args[@]}" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" "${workdir}"
+
+
+  echo "~~~ Uncompressing ${paths[@]} from ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
+  "${compress[@]}" "${paths[@]}"
+
+  index=0
+  for path in "${paths[@]}"; do
+    source_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_FROM"
+    dest_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_TO"
+    if [[ -n "${!dest_env_var:-}" ]]; then
+      if ! [[ -d $(dirname "${!dest_env_var}") ]]; then
+        mkdir -p "$(dirname "${!dest_env_var}")"
+      fi
+      echo "~~~ Moving [${!source_env_var}] to [${!dest_env_var}]..."
+      mv "${!source_env_var}" "${!dest_env_var}"
+    fi
+ 
+    ((index+=1))
+  done
+elif [[ "${SINGULAR_DOWNLOAD_OBJECT}" == "true" ]]; then
   if [[ "${RELOCATION}" == "true" ]]; then
     source="${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM}"
   else

--- a/plugin.yml
+++ b/plugin.yml
@@ -44,7 +44,9 @@ configuration:
       type: string
     gs-upload-acl:
       type: string
-
+    compressed:
+      type: string
+      pattern: '.*(.zip|.tgz)$'
   oneOf:
     - required:
       - upload

--- a/tests/download-compressed.bats
+++ b/tests/download-compressed.bats
@@ -1,0 +1,373 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+# Uncomment to enable stub debug output:
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+
+@test "Invalid compressed format" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD="file.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.rar"
+  
+  run "$PWD/hooks/pre-command"
+
+  assert_failure
+  assert_output --partial "The inferred compression file format for the artifact is not currently supported"
+  refute_output --partial "Downloading artifacts"
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Single value zip" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
+  
+  stub buildkite-agent \
+    "artifact download \* \* : echo downloaded \$3 to \$4"
+
+  stub unzip \
+    "\* \* : echo extracted \$2 from \$1"
+
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts"
+  assert_output --partial "Uncompressing *.log from file.zip"
+  refute_output --partial "downloaded *.log"
+
+  unstub buildkite-agent
+  unstub unzip
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Single value tgz" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
+  
+  stub buildkite-agent \
+    "artifact download \* \* : echo downloaded \$3 to \$4"
+
+  stub tar \
+    "xzf \* \* : echo extracted \$3 from \$2"
+
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts"
+  assert_output --partial "Uncompressing *.log from file.tgz"
+  refute_output --partial "downloaded *.log"
+
+  unstub buildkite-agent
+  unstub tar
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Single zip with relocation" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM="/tmp/foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO="/tmp/foo2.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
+
+  stub buildkite-agent \
+    "artifact download \* \* : echo downloaded \$3 to \$4"
+
+  stub unzip \
+    "\* \* : echo extracted \$2 from \$1; touch \$2"
+
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts"
+  assert_output --partial "Uncompressing /tmp/foo.log from file.zip"
+  assert_output --partial "Moving [/tmp/foo.log]"
+  refute_output --partial "downloaded /tmp/foo.log"
+  refute_output --partial "downloaded /tmp/foo2.log"
+
+  assert [ ! -e /tmp/foo.log ]
+  assert [ -e /tmp/foo2.log ]
+  rm /tmp/foo2.log
+
+  unstub buildkite-agent
+  unstub unzip
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Single tgz with relocation" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM="/tmp/foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO="/tmp/foo2.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
+
+  stub buildkite-agent \
+    "artifact download \* \* : echo downloaded \$3 to \$4"
+
+  stub tar \
+    "xzf \* \* : echo extracted \$3 from \$2; touch \$3"
+
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts"
+  assert_output --partial "Uncompressing /tmp/foo.log from file.tgz"
+  assert_output --partial "Moving [/tmp/foo.log]"
+  refute_output --partial "downloaded /tmp/foo.log"
+  refute_output --partial "downloaded /tmp/foo2.log"
+
+  assert [ ! -e /tmp/foo.log ]
+  assert [ -e /tmp/foo2.log ]
+  rm /tmp/foo2.log
+
+  unstub buildkite-agent
+  unstub tar
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Single value zip with step" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_STEP="54321"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
+
+  stub buildkite-agent \
+    "artifact download --step \* \* \* : echo downloaded \$5 to \$6 with --step \$4"
+
+  stub unzip \
+    "\* \* : echo extracted \$2 from \$1"
+
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts (extra args: '--step 54321')"
+  assert_output --partial "Uncompressing *.log from file.zip"
+  refute_output --partial "downloaded *.log"
+
+  unstub buildkite-agent
+  unstub unzip
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_STEP
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Single value tgz with step" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_STEP="54321"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
+
+  stub buildkite-agent \
+    "artifact download --step \* \* \* : echo downloaded \$5 to \$6 with --step \$4"
+
+  stub tar \
+    "xzf \* \* : echo extracted \$3 from \$2"
+
+
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts (extra args: '--step 54321')"
+  assert_output --partial "Uncompressing *.log from file.tgz"
+  refute_output --partial "downloaded *.log"
+
+  unstub buildkite-agent
+  unstub tar
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_STEP
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Single value zip with build" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_BUILD="12345"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
+
+  stub buildkite-agent \
+    "artifact download --build \* \* \* : echo downloaded artifact \$5 to \$6 with --build \$4"
+
+  stub unzip \
+    "\* \* : echo extracted \$2 from \$1"
+
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts (extra args: '--build 12345')"
+  assert_output --partial "Uncompressing *.log from file.zip"
+  refute_output --partial "downloaded *.log"
+
+  unstub buildkite-agent
+  unstub unzip
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_BUILD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Single value tgz with build" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_BUILD="12345"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
+
+  stub buildkite-agent \
+    "artifact download --build \* \* \* : echo downloaded artifact \$5 to \$6 with --build \$4"
+
+  stub tar \
+    "xzf \* \* : echo extracted \$3 from \$2"
+
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts (extra args: '--build 12345')"
+  assert_output --partial "Uncompressing *.log from file.tgz"
+  refute_output --partial "downloaded *.log"
+
+  unstub buildkite-agent
+  unstub tar
+  
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_BUILD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Multiple files from zip" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0="foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1="bar.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2="baz.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
+
+  stub buildkite-agent \
+    "artifact download \* \* : echo downloaded artifact \$3 to \$4"
+
+  stub unzip \
+    "\* \* : echo extracted \$2 from \$1"
+
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts"
+  assert_output --partial "Uncompressing foo.log bar.log baz.log from file.zip"
+  refute_output --partial "downloaded foo.log"
+  refute_output --partial "downloaded bar.log"
+  refute_output --partial "downloaded baz.log"
+
+  unstub buildkite-agent
+  unstub unzip
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Multiple files from tgz" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0="foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1="bar.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2="baz.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
+
+  stub buildkite-agent \
+    "artifact download \* \* : echo downloaded artifact \$3 to \$4"
+
+  stub tar \
+    "xzf \* \* : echo extracted \$3 from \$2"
+
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts"
+  assert_output --partial "Uncompressing foo.log bar.log baz.log from file.tgz"
+  refute_output --partial "downloaded foo.log"
+  refute_output --partial "downloaded bar.log"
+  refute_output --partial "downloaded baz.log"
+
+  unstub buildkite-agent
+  unstub tar
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Multiple files from zip with some relocation" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_FROM="/tmp/foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_TO="/tmp/foo2.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1="bar.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2="baz.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
+
+  stub buildkite-agent \
+    "artifact download \* \* : echo downloaded artifact \$3 to \$4"
+
+  stub unzip \
+    "\* \* \* \* : echo extracted \$2, \$3 and \$4 from \$1; touch \$2"
+
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts"
+  assert_output --partial "Uncompressing /tmp/foo.log bar.log baz.log from file.zip"
+  assert_output --partial "Moving [/tmp/foo.log]"
+  refute_output --partial "downloaded /tmp/foo.log"
+  refute_output --partial "downloaded /tmp/foo2.log"
+  refute_output --partial "downloaded bar.log"
+  refute_output --partial "downloaded baz.log"
+
+  assert [ ! -e /tmp/foo.log ]
+  assert [ -e /tmp/foo2.log ]
+  rm /tmp/foo2.log
+
+  unstub buildkite-agent
+  unstub unzip
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Multiple files from tgz with some relocation" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_FROM="/tmp/foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_TO="/tmp/foo2.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1="bar.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2="baz.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
+
+  stub buildkite-agent \
+    "artifact download \* \* : echo downloaded artifact \$3 to \$4"
+
+  stub tar \
+    "xzf \* \* \* \* : echo extracted \$3, \$4 and \$5 from \$2; touch \$3"
+
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts"
+  assert_output --partial "Uncompressing /tmp/foo.log bar.log baz.log from file.tgz"
+  assert_output --partial "Moving [/tmp/foo.log]"
+  refute_output --partial "downloaded /tmp/foo.log"
+  refute_output --partial "downloaded /tmp/foo2.log"
+  refute_output --partial "downloaded bar.log"
+  refute_output --partial "downloaded baz.log"
+
+  assert [ ! -e /tmp/foo.log ]
+  assert [ -e /tmp/foo2.log ]
+  rm /tmp/foo2.log
+
+  unstub buildkite-agent
+  unstub tar
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}

--- a/tests/upload-compressed.bats
+++ b/tests/upload-compressed.bats
@@ -1,0 +1,334 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+# Uncomment to enable stub debug output:
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+
+@test "Invalid compressed format" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="file.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.rar"
+
+  run "$PWD/hooks/post-command"
+
+  assert_failure
+  assert_output --partial "The inferred compression file format for the artifact is not currently supported"
+  refute_output --partial "Uploading artifacts"
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Single value zip" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
+
+  stub buildkite-agent \
+    "artifact upload \* : echo uploaded \$3"
+
+  stub zip \
+    "\* \* : echo zipped \$2 into \$1"
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Compressing *.log to file.zip"
+  assert_output --partial "Uploading artifacts"
+  assert_output --partial "uploaded file.zip"
+
+  unstub buildkite-agent
+  unstub zip
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Single value tgz" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
+
+  stub buildkite-agent \
+    "artifact upload \* : echo uploaded \$3"
+
+  stub tar \
+    "czf \* \* : echo targzd \$3 into \$2"
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Compressing *.log to file.tgz"
+  assert_output --partial "Uploading artifacts"
+  assert_output --partial "uploaded file.tgz"
+
+  unstub buildkite-agent
+  unstub tar
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Single file zip with relocation" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM="/tmp/foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_TO="/tmp/foo2.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
+
+  stub buildkite-agent \
+    "artifact upload \* : echo uploaded \$3"
+
+  stub zip \
+    "\* \* : echo zipped \$2 into \$1"
+
+  touch /tmp/foo.log
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Moving [/tmp/foo.log]"
+  assert_output --partial "Compressing /tmp/foo2.log to file.zip"
+  assert_output --partial "Uploading artifacts"
+  assert_output --partial "uploaded file.zip"
+  refute_output --partial "uploaded /tmp/foo.log"
+  refute_output --partial "uploaded /tmp/foo2.log"
+
+  assert [ -e /tmp/foo2.log ]
+  assert [ ! -e /tmp/foo.log ]
+  rm /tmp/foo2.log
+
+  unstub buildkite-agent
+  unstub zip
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Single file tgz with relocation" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM="/tmp/foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_TO="/tmp/foo2.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
+
+  stub buildkite-agent \
+    "artifact upload \* : echo uploaded \$3"
+
+  stub tar \
+    "czf \* \* : echo targzd \$3 into \$2"
+
+  touch /tmp/foo.log
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Moving [/tmp/foo.log]"
+  assert_output --partial "Compressing /tmp/foo2.log to file.tgz"
+  assert_output --partial "Uploading artifacts"
+  assert_output --partial "uploaded file.tgz"
+  refute_output --partial "uploaded /tmp/foo.log"
+  refute_output --partial "uploaded /tmp/foo2.log"
+
+  assert [ -e /tmp/foo2.log ]
+  assert [ ! -e /tmp/foo.log ]
+  rm /tmp/foo2.log
+
+  unstub buildkite-agent
+  unstub tar
+  
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Single value zip with job" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_JOB="12345"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
+
+  stub buildkite-agent \
+    "artifact upload --job \* \* : echo uploaded \$5 with --job \$4"
+
+  stub zip \
+    "\* \* : echo zipped \$2 into \$1"
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Uploading artifacts (extra args: '--job 12345')"
+  assert_output --partial "Compressing *.log to file.zip"
+  assert_output --partial "uploaded file.zip"
+  refute_output --partial "uploaded *.log"
+  
+  unstub buildkite-agent
+  unstub zip
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_JOB
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Single value tgz with job" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_JOB="12345"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
+
+  stub buildkite-agent \
+    "artifact upload --job \* \* : echo uploaded \$5 with --job \$4"
+
+  stub tar \
+    "czf \* \* : echo targzd \$3 into \$2"
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Uploading artifacts (extra args: '--job 12345')"
+  assert_output --partial "Compressing *.log to file.tgz"
+  assert_output --partial "uploaded file.tgz"
+  refute_output --partial "uploaded *.log"
+  
+  unstub buildkite-agent
+  unstub tar
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
+  unset BUILDKITE_PLUGIN_ARTIFACTS_JOB
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Multiple artifacts zip" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0="/tmp/foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1="bar.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2="baz.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
+
+  stub buildkite-agent \
+    "artifact upload \* : echo uploaded \$3"
+
+  stub zip \
+    "\* \* \* \* : echo zipped \$2, \$3 and \$4 into \$1"
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Uploading artifacts"
+  assert_output --partial "Compressing /tmp/foo.log bar.log baz.log to file.zip"
+  assert_output --partial "uploaded file.zip"
+  refute_output --partial "uploaded /tmp/foo.log"
+  refute_output --partial "uploaded baar.log"
+  refute_output --partial "uploaded baz.log"
+
+  unstub buildkite-agent
+  unstub zip
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Multiple artifacts tgz" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0="/tmp/foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1="bar.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2="baz.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
+
+  stub buildkite-agent \
+    "artifact upload \* : echo uploaded \$3"
+
+  stub tar \
+    "czf \* \* \* \* : echo zipped \$3, \$4 and \$5 into \$2"
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Uploading artifacts"
+  assert_output --partial "Compressing /tmp/foo.log bar.log baz.log to file.tgz"
+  assert_output --partial "uploaded file.tgz"
+  refute_output --partial "uploaded /tmp/foo.log"
+  refute_output --partial "uploaded baar.log"
+  refute_output --partial "uploaded baz.log"
+
+  unstub buildkite-agent
+  unstub tar
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Multiple artifacs zip some relocation" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_FROM="/tmp/foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_TO="/tmp/foo2.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1="bar.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2="baz.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
+
+  touch /tmp/foo.log
+
+  stub buildkite-agent \
+    "artifact upload \* : echo uploaded \$3"
+
+  stub zip \
+    "\* \* \* \* : echo zipped \$2, \$3 and \$4 into \$1"
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Uploading artifacts"
+  assert_output --partial "Moving [/tmp/foo.log]"
+  assert_output --partial "Compressing /tmp/foo2.log bar.log baz.log to file.zip"
+  refute_output --partial "uploaded /tmp/foo.log"
+  refute_output --partial "uploaded /tmp/foo2.log"
+  refute_output --partial "uploaded bar.log"
+  refute_output --partial "uploaded baz.log"
+
+  assert [ -e /tmp/foo2.log ]
+  assert [ ! -e /tmp/foo.log ]
+  rm /tmp/foo2.log
+
+  unstub buildkite-agent
+  unstub zip
+  
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}
+
+@test "Multiple artifacs tgz some relocation" {
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_FROM="/tmp/foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_TO="/tmp/foo2.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1="bar.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2="baz.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
+
+  touch /tmp/foo.log
+
+  stub buildkite-agent \
+    "artifact upload \* : echo uploaded \$3"
+
+  stub tar \
+    "czf \* \* \* \* : echo targzd \$3, \$4 and \$5 into \$2"
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Uploading artifacts"
+  assert_output --partial "Moving [/tmp/foo.log]"
+  assert_output --partial "Compressing /tmp/foo2.log bar.log baz.log to file.tgz"
+  refute_output --partial "uploaded /tmp/foo.log"
+  refute_output --partial "uploaded /tmp/foo2.log"
+  refute_output --partial "uploaded bar.log"
+  refute_output --partial "uploaded baz.log"
+
+  assert [ -e /tmp/foo2.log ]
+  assert [ ! -e /tmp/foo.log ]
+  rm /tmp/foo2.log
+
+  unstub buildkite-agent
+  unstub tar
+
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_FROM
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_TO
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2
+  unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+}


### PR DESCRIPTION
This is a first attempt at an implementation of compression of artifacts.

Right now it only supports `tgz` and `zip` files and assumes the correct binaries are available to work with them.

I created extensive amounts of tests but have not had to test it just yet. Will do so in the next few days but wanted to put the code out more prominently for others to review and test if they need/want

Closes #30 