### PR TITLE
Per-artifact step/build

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This functionality duplicates the [artifact_paths](https://buildkite.com/docs/pi
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.7.0:
+    - artifacts#v1.8.0:
         upload: "log/**/*.log"
 ```
 
@@ -20,7 +20,7 @@ You can specify multiple files/globs to upload as artifacts:
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.7.0:
+    - artifacts#v1.8.0:
         upload: [ "log/**/*.log", "debug/*.error" ]
 ```
 
@@ -30,7 +30,7 @@ And even rename them before uploading them (can not use globs here though, sorry
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.7.0:
+    - artifacts#v1.8.0:
         upload: 
           - from: log1.log
             to: log2.log
@@ -47,7 +47,7 @@ eg: uploading a public file when using S3
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.7.0:
+    - artifacts#v1.8.0:
         upload: "coverage-report/**/*"
         s3-upload-acl: public-read
 ```
@@ -57,7 +57,7 @@ eg: uploading a private file when using GS
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.7.0:
+    - artifacts#v1.8.0:
         upload: "coverage-report/**/*"
         gs-upload-acl: private
 ```
@@ -70,7 +70,7 @@ This downloads artifacts matching globs to the local filesystem. See [downloadin
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.7.0:
+      - artifacts#v1.8.0:
           download: "log/**/*.log"
 ```
 
@@ -80,7 +80,7 @@ You can specify multiple files/patterns:
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.7.0:
+      - artifacts#v1.8.0:
           download: [ "log/**/*.log", "debug/*.error" ]
 ```
 
@@ -90,7 +90,7 @@ Rename particular files after downloading them:
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.7.0:
+      - artifacts#v1.8.0:
           download: 
             - from: log1.log
               to: log2.log
@@ -102,7 +102,7 @@ And even do so from different builds/steps:
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.7.0:
+      - artifacts#v1.8.0:
           step: UUID-DEFAULT
           build: UUID-DEFAULT-2
           download: 
@@ -144,7 +144,7 @@ When uploading, globs specified in the `upload` option will be compressed in a s
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.7.0:
+    - artifacts#v1.8.0:
         upload: "log/*.log"
         compressed: logs.zip
 ```
@@ -155,7 +155,7 @@ When downloading, this option states the actual name of the artifact to be downl
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.7.0:
+      - artifacts#v1.8.0:
           download: "log/*.log"
           compressed: logs.tgz
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ steps:
         upload: "log/**/*.log"
 ```
 
-or
+You can specify multiple files/globs to upload as artifacts:
 
 ```yml
 steps:
@@ -24,7 +24,7 @@ steps:
         upload: [ "log/**/*.log", "debug/*.error" ]
 ```
 
-or
+And even rename them before uploading them (can not use globs here though, sorry):
 
 ```yml
 steps:
@@ -32,23 +32,12 @@ steps:
     plugins:
     - artifacts#v1.7.0:
         upload: 
-          from: log1.log
-          to: log2.log
-```
-
-or
-
-```yml
-steps:
-  - command: ...
-    plugins:
-    - artifacts#v1.7.0:
-        upload: 
-        - from: log1.log
-          to: log2.log
+          - from: log1.log
+            to: log2.log
 ```
 
 ### User-defined ACL on uploaded files
+
 When using AWS S3 or Google Cloud Storage as your artifact store, you can optionally define an object-level ACL for your uploaded artifacts. This allows you to have granular control over which artifacts are made public or private.
 
 If not specified it will respect the relevant setting at the agent level.
@@ -85,7 +74,7 @@ steps:
           download: "log/**/*.log"
 ```
 
-or
+You can specify multiple files/patterns:
 
 ```yml
 steps:
@@ -95,7 +84,7 @@ steps:
           download: [ "log/**/*.log", "debug/*.error" ]
 ```
 
-or
+Rename particular files after downloading them:
 
 ```yml
 steps:
@@ -103,20 +92,26 @@ steps:
     plugins:
       - artifacts#v1.7.0:
           download: 
-            from: log1.log
-            to: log2.log
+            - from: log1.log
+              to: log2.log
 ```
 
-or
+And even do so from different builds/steps:
 
 ```yml
 steps:
   - command: ...
     plugins:
       - artifacts#v1.7.0:
+          step: UUID-DEFAULT
+          build: UUID-DEFAULT-2
           download: 
-          - from: log1.log
-            to: log2.log
+            - from: log1.log
+              to: log2.log
+              step: UUID-1
+            - from: log3.log
+              to: log4.log
+              build: UUID-2
 ```
 
 ## Configuration
@@ -125,17 +120,17 @@ steps:
 
 A glob pattern, or array of glob patterns, for files to upload.
 
-### `download` (string, array of strings, {from,to}, array of {from,to})
+### `download` (string, array of strings, {from,to}, array of {from,to[,step][,build]})
 
 A glob pattern, or array of glob patterns, for files to download.
 
 ### `step` (optional, string)
 
-The job UUID or name to download the artifact from.
+The job UUID or name to download the artifacts from unless specified otherwise in the `download` array specification.
 
 ### `build` (optional, string)
 
-The build UUID to download the artifact from.
+The build UUID to download the artifact from unless specificed otherwise in the `download` array specification.
 
 ### `compressed` (optional, string)
 
@@ -168,11 +163,6 @@ steps:
 ### `ignore-missing` (optional, boolean)
 
 If set to `true`, it will ignore errors caused when calling `buildkite-agent artifact` to prevent failures if you expect artifacts not to be present in some situations.
-
-### Relocation
-
-If a file needs to be renamed or moved before upload or after download, a nested object is used with `to` and `from` keys.
-At this time, this can only be used with single files and does not support glob patterns.
 
 ## Developing
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -6,15 +6,8 @@ if [[ "${BUILDKITE_PLUGIN_ARTIFACTS_DEBUG:-false}" =~ (true|on|1) ]] ; then
   set -x
 fi
 
-args=("download")
-
-if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_STEP:-}" ]] ; then
-  args+=("--step" "${BUILDKITE_PLUGIN_ARTIFACTS_STEP}")
-fi
-
-if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_BUILD:-}" ]] ; then
-  args+=("--build" "${BUILDKITE_PLUGIN_ARTIFACTS_BUILD}")
-fi
+step_option="${BUILDKITE_PLUGIN_ARTIFACTS_STEP:-}"
+build_option="${BUILDKITE_PLUGIN_ARTIFACTS_BUILD:-}"
 
 paths=()
 compress=()
@@ -47,7 +40,31 @@ if [[ "${#paths[@]}" -le 0 ]]; then
 fi
 
 bk_agent() {
-  if ! buildkite-agent artifact "${@}"; then
+  # first two options must be step and build (but can be empty)
+  step="${1}"
+  shift
+  build="${1}"
+  shift
+
+  options=('download')
+  if [ -n "$step" ]; then
+    options+=("--step" "${step}")
+  fi
+
+  if [ -n "$build" ]; then
+    options+=("--build" "${build}")
+  fi
+
+  if [[ "${#options[@]}" -gt 1 ]]; then
+    EXTRA_MESSAGE="(extra args: '${options[*]:1}')"
+  else
+    EXTRA_MESSAGE=""
+  fi
+
+  options+=("${@}")  # all the rest
+
+  echo "~~~ Downloading artifacts ${EXTRA_MESSAGE}"
+  if ! buildkite-agent artifact "${options[@]}"; then
     if [[ "${BUILDKITE_PLUGIN_ARTIFACTS_IGNORE_MISSING:-"false"}" != "false" ]]; then
       echo "Ignoring error in download of" "${@: -2}"
     else
@@ -94,17 +111,10 @@ if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED:-}" ]]; then
   fi
 fi
 
-if [[ "${#args[@]}" -gt 1 ]]; then
-  EXTRA_MESSAGE="(extra args: '${args[*]:1}')"
-else
-  EXTRA_MESSAGE=""
-fi
-
 workdir="${BUILDKITE_PLUGIN_ARTIFACTS_WORKDIR:-.}"
 
 if [[ "${COMPRESSED}" == "true" ]]; then
-  echo "~~~ Downloading artifacts ${EXTRA_MESSAGE}"
-  bk_agent "${args[@]}" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" "${workdir}"
+  bk_agent "${step_option}" "${build_option}" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" "${workdir}"
 
   echo "~~~ Uncompressing ${paths[*]} from ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
   "${compress[@]}" "${paths[@]}"
@@ -128,8 +138,7 @@ elif [[ "${SINGULAR_DOWNLOAD_OBJECT}" == "true" ]]; then
     source="${paths[*]}"
   fi
 
-  echo "~~~ Downloading artifacts ${EXTRA_MESSAGE}"
-  bk_agent "${args[@]}" "${source}" "${workdir}"
+  bk_agent "${step_option}" "${build_option}" "${source}" "${workdir}"
 
   if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO:-}" ]]; then
     handle_relocation ""
@@ -137,31 +146,20 @@ elif [[ "${SINGULAR_DOWNLOAD_OBJECT}" == "true" ]]; then
 elif [[ "${MULTIPLE_DOWNLOADS}" == "true" ]]; then
   index=0
 
-  echo "~~~ Downloading artifacts ${EXTRA_MESSAGE}"
   for path in "${paths[@]}"; do
     source_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_FROM"
     dest_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_TO"
     step_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_STEP"
     build_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_BUILD"
 
-    per_file_options=()
-
-    if [[ -n "${!step_env_var:-}" ]]; then
-      per_file_options+=("--step" "${!step_env_var}")
-    fi
-
-    if [[ -n "${!build_env_var:-}" ]]; then
-      per_file_options+=("--build" "${!build_env_var}")
-    fi
-
     # finally get the artifact to download
-    if [[ -n "${!source_env_var:-}" ]] && [[ -n "${!dest_env_var:-}" ]]; then
-      per_file_options+=("${!source_env_var}")
+    if [ -n "${!source_env_var:-}" ] && [ -n "${!dest_env_var:-}" ]; then
+      source="${!source_env_var}"
     else
-      per_file_options+=("${path}")
+      source="${path}"
     fi
 
-    bk_agent "${args[@]}" "${per_file_options[@]}" "${workdir}"
+    bk_agent "${!step_env_var:-${step_option}}" "${!build_env_var:-${build_option}}" "${source}" "${workdir}"
 
     handle_relocation "${index}"
     ((index+=1))

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -35,7 +35,7 @@ if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD:-}" ]] || { [[ -n "${BUILDKITE_P
 fi
 
 while IFS='=' read -r path _ ; do
-  if [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+) ]] && ! [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+_TO) ]]; then
+  if [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+)$ ]] || [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+_FROM)$ ]]; then
     MULTIPLE_DOWNLOADS="true"
     paths+=("${!path}")
   fi
@@ -141,12 +141,28 @@ elif [[ "${MULTIPLE_DOWNLOADS}" == "true" ]]; then
   for path in "${paths[@]}"; do
     source_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_FROM"
     dest_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_TO"
-    if [[ -n "${!source_env_var:-}" ]] && [[ -n "${!dest_env_var:-}" ]]; then
-      source="${!source_env_var}"
-    else
-      source="${path}"
+    step_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_STEP"
+    build_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_BUILD"
+
+    per_file_options=()
+
+    if [[ -n "${!step_env_var:-}" ]]; then
+      per_file_options+=("--step" "${!step_env_var}")
     fi
-    bk_agent "${args[@]}" "${source}" "${workdir}"
+
+    if [[ -n "${!build_env_var:-}" ]]; then
+      per_file_options+=("--build" "${!build_env_var}")
+    fi
+
+    # finally get the artifact to download
+    if [[ -n "${!source_env_var:-}" ]] && [[ -n "${!dest_env_var:-}" ]]; then
+      per_file_options+=("${!source_env_var}")
+    else
+      per_file_options+=("${path}")
+    fi
+
+    bk_agent "${args[@]}" "${per_file_options[@]}" "${workdir}"
+
     handle_relocation "${index}"
     ((index+=1))
   done

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,6 +12,10 @@ configuration:
           type: string
         to:
           type: string
+        step:
+          type: string
+        build:
+          type: string
       required:
         - from
         - to

--- a/tests/download.bats
+++ b/tests/download.bats
@@ -234,9 +234,13 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1="bar.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2_FROM="/tmp/foo3.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2_BUILD="0007"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_3_FROM="/tmp/foo4.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_3_BUILD="0007"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_3_STEP="0001"
 
   stub buildkite-agent \
     "artifact download --step \* --build \* \* \* : touch \$7; echo downloaded artifact \$7 with step \$4 and build \$6" \
+    "artifact download --step \* --build \* \* \* : echo downloaded artifact \$7 with step \$4 and build \$6" \
     "artifact download --step \* --build \* \* \* : echo downloaded artifact \$7 with step \$4 and build \$6" \
     "artifact download --step \* --build \* \* \* : echo downloaded artifact \$7 with step \$4 and build \$6"
 
@@ -252,6 +256,7 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "/tmp/foo1.log with step 0001 and build 12345"
   assert_output --partial       "bar.log with step 6789 and build 12345"
   assert_output --partial "/tmp/foo3.log with step 6789 and build 0007"
+  assert_output --partial "/tmp/foo4.log with step 0001 and build 0007"
 
   unstub buildkite-agent
 }

--- a/tests/download.bats
+++ b/tests/download.bats
@@ -237,8 +237,8 @@ load '/usr/local/lib/bats/load.bash'
 
   stub buildkite-agent \
     "artifact download --step \* --build \* \* \* : touch \$7; echo downloaded artifact \$7 with step \$4 and build \$6" \
-    "artifact download --step \* --build \* \* \* : touch \$7; echo downloaded artifact \$7 with step \$4 and build \$6" \
-    "artifact download --step \* --build \* \* \* : touch \$7; echo downloaded artifact \$7 with step \$4 and build \$6"
+    "artifact download --step \* --build \* \* \* : echo downloaded artifact \$7 with step \$4 and build \$6" \
+    "artifact download --step \* --build \* \* \* : echo downloaded artifact \$7 with step \$4 and build \$6"
 
   run "$PWD/hooks/pre-command"
 
@@ -248,6 +248,7 @@ load '/usr/local/lib/bats/load.bash'
   assert [ -e /tmp/foo2.log ]
   rm /tmp/foo2.log
   assert [ ! -e /tmp/foo1.log ]
+
   assert_output --partial "/tmp/foo1.log with step 0001 and build 12345"
   assert_output --partial       "bar.log with step 6789 and build 12345"
   assert_output --partial "/tmp/foo3.log with step 6789 and build 0007"


### PR DESCRIPTION
Based on #47 I have refactored the download code so that you can now specify per-artifact step and/or build.

The `step`/`build` configurations on the plugin level will be used as default if none is specified in a particular artifact.