### PR TITLE
Skip on exit codes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: "🤡 :hammer:"
     plugins:
-      - docker-compose#v4.5.0:
+      - docker-compose#v4.9.0:
           run: tests
   - label: ":sparkles: lint"
     plugins:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This functionality duplicates the [artifact_paths](https://buildkite.com/docs/pi
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.8.0:
+    - artifacts#v1.9.0:
         upload: "log/**/*.log"
 ```
 
@@ -20,7 +20,7 @@ You can specify multiple files/globs to upload as artifacts:
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.8.0:
+    - artifacts#v1.9.0:
         upload: [ "log/**/*.log", "debug/*.error" ]
 ```
 
@@ -30,7 +30,7 @@ And even rename them before uploading them (can not use globs here though, sorry
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.8.0:
+    - artifacts#v1.9.0:
         upload: 
           - from: log1.log
             to: log2.log
@@ -47,7 +47,7 @@ eg: uploading a public file when using S3
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.8.0:
+    - artifacts#v1.9.0:
         upload: "coverage-report/**/*"
         s3-upload-acl: public-read
 ```
@@ -57,7 +57,7 @@ eg: uploading a private file when using GS
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.8.0:
+    - artifacts#v1.9.0:
         upload: "coverage-report/**/*"
         gs-upload-acl: private
 ```
@@ -70,7 +70,7 @@ This downloads artifacts matching globs to the local filesystem. See [downloadin
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.8.0:
+      - artifacts#v1.9.0:
           download: "log/**/*.log"
 ```
 
@@ -80,7 +80,7 @@ You can specify multiple files/patterns:
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.8.0:
+      - artifacts#v1.9.0:
           download: [ "log/**/*.log", "debug/*.error" ]
 ```
 
@@ -90,7 +90,7 @@ Rename particular files after downloading them:
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.8.0:
+      - artifacts#v1.9.0:
           download: 
             - from: log1.log
               to: log2.log
@@ -102,7 +102,7 @@ And even do so from different builds/steps:
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.8.0:
+      - artifacts#v1.9.0:
           step: UUID-DEFAULT
           build: UUID-DEFAULT-2
           download: 
@@ -144,7 +144,7 @@ When uploading, globs specified in the `upload` option will be compressed in a s
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.8.0:
+    - artifacts#v1.9.0:
         upload: "log/*.log"
         compressed: logs.zip
 ```
@@ -155,7 +155,7 @@ When downloading, this option states the actual name of the artifact to be downl
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.8.0:
+      - artifacts#v1.9.0:
           download: "log/*.log"
           compressed: logs.tgz
 ```
@@ -176,7 +176,7 @@ Skip uploading if the main command failed with exit code 147:
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.8.0:
+    - artifacts#v1.9.0:
         upload: "log/*.log"
         skip-on-status: 147
 ```
@@ -187,7 +187,7 @@ Alternatively, skip artifact uploading on exit codes 1 and 5:
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.8.0:
+    - artifacts#v1.9.0:
         upload: "log/*.log"
         skip-on-status:
           - 1

--- a/README.md
+++ b/README.md
@@ -164,6 +164,36 @@ steps:
 
 If set to `true`, it will ignore errors caused when calling `buildkite-agent artifact` to prevent failures if you expect artifacts not to be present in some situations.
 
+### `skip-on-status` (optional, integer or array of integers, uploads only)
+
+You can set this to the exit codes or array of exit codes of the command step (as defined by the `BUILDKITE_COMMAND_EXIT_STATUS` variable) that will cause the plugin to avoid trying to upload artifacts.
+
+This should allow you to specify known failure conditions that you want to avoid uploading artifacts. For example, because you know logs will be huge or not useful.
+
+Skip uploading if the main command failed with exit code 147:
+
+```yml
+steps:
+  - command: ...
+    plugins:
+    - artifacts#v1.8.0:
+        upload: "log/*.log"
+        skip-on-status: 147
+```
+
+Alternatively, skip artifact uploading on exit codes 1 and 5:
+
+```yml
+steps:
+  - command: ...
+    plugins:
+    - artifacts#v1.8.0:
+        upload: "log/*.log"
+        skip-on-status:
+          - 1
+          - 5
+```
+
 ## Developing
 
 To run testing, shellchecks and plugin linting use use `bk run` with the [Buildkite CLI](https://github.com/buildkite/cli).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2'
 services:
   tests:
-    image: buildkite/plugin-tester:v3.0.1
+    image: buildkite/plugin-tester:v4.0.0
     volumes:
       - ".:/plugin:ro"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -6,6 +6,15 @@ if [[ "${BUILDKITE_PLUGIN_ARTIFACTS_DEBUG:-false}" =~ (true|on|1) ]] ; then
   set -x
 fi
 
+while IFS='=' read -r EXIT_VAR _ ; do
+  if [[ $EXIT_VAR =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_SKIP_ON_STATUS(|_[0-9]+))$ ]]; then
+    if [ "${BUILDKITE_COMMAND_EXIT_STATUS}" -eq "${!EXIT_VAR}" ]; then
+      echo "Command exit status matches ${!EXIT_VAR}, skipping upload"
+      exit 0
+    fi
+  fi
+done < <(env | sort)
+
 args=("upload")
 
 if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_JOB:-}" ]] ; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -53,9 +53,17 @@ configuration:
       pattern: '.*(.zip|.tgz)$'
     ignore-missing:
       type: boolean
+    skip-on-status:
+      oneOf:
+        - type: integer
+        - type: array
+          items:
+            type: integer
   oneOf:
     - required:
       - upload
     - required:
       - download
+  dependencies:
+    skip-on-status: [ upload ]
   additionalProperties: false

--- a/tests/download-compressed.bats
+++ b/tests/download-compressed.bats
@@ -246,7 +246,7 @@ load '/usr/local/lib/bats/load.bash'
     "artifact download \* \* : echo downloaded artifact \$3 to \$4"
 
   stub unzip \
-    "\* \* : echo extracted \$2 from \$1"
+    "\* \* \* \* : echo extracted \$2, \$3 and \$4 from \$1"
 
   run "$PWD/hooks/pre-command"
 
@@ -276,7 +276,7 @@ load '/usr/local/lib/bats/load.bash'
     "artifact download \* \* : echo downloaded artifact \$3 to \$4"
 
   stub tar \
-    "xzf \* \* : echo extracted \$3 from \$2"
+    "xzf \* \* \* \* : echo extracted \$3, \$4 and \$5 from \$2"
 
   run "$PWD/hooks/pre-command"
 


### PR DESCRIPTION
Adds a new option to allow skipping uploads on specific exit codes (closes #78)

While at it, also updates plugin tester (fixing tests that were missing stub arguments) and compose plugin.