### PR TITLE
Sup 1358 fix recursive zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,29 +134,30 @@ The build UUID to download the artifact from unless specificed otherwise in the 
 
 ### `compressed` (optional, string)
 
-Limitations:
+⚠️ Limitations:
 * filename needs to end with `.zip` or `.tgz` and that will determine the compression executable to use
-* path globs (`*`) are interpreted by agent's shell and (un)compressing program (meaning that probably `**` will not work)
+* path globs (`*`) are interpreted by agent's shell and (un)compressing program, meaning that `*` and `**` will not work.
 
-When uploading, globs specified in the `upload` option will be compressed in a single file with this name and uploaded as a single artifact. The following example will get all files matching `log/*.log`, zip them up and upload a single artifact file named `logs.zip`:
+When uploading, the file or directory specified in the `upload` option will be compressed in a single file with this name and uploaded as a single artifact. The following example will get the directory matching `log/my-folder`, zip them up and upload a single artifact file named `logs.zip`:
+
 
 ```yml
 steps:
   - command: ...
     plugins:
     - artifacts#v1.9.0:
-        upload: "log/*.log"
+        upload: "log/my-folder"
         compressed: logs.zip
 ```
 
-When downloading, this option states the actual name of the artifact to be downloaded and globs in the `download` option will be extracted off of it. The following example will download the `logs.tgz` artifact and extract all files in it matching `log/*.log`:
+When downloading, this option states the actual name of the artifact to be downloaded in the `download` option will be extracted off of it. The following example will download the `logs.tgz` artifact and extract all files in it matching `log/file.log`:
 
 ```yml
 steps:
   - command: ...
     plugins:
       - artifacts#v1.9.0:
-          download: "log/*.log"
+          download: "log/file.log"
           compressed: logs.tgz
 ```
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -55,7 +55,7 @@ if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED:-}" ]]; then
   COMPRESSED="true"
 
   if [[ "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" =~ .*\.zip ]]; then
-    compress+=("zip" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}")
+    compress+=("zip" "-r" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}")
   elif [[ "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" =~ .*\.tgz ]]; then
     compress+=("tar" "czf" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}")
   else

--- a/tests/upload-compressed.bats
+++ b/tests/upload-compressed.bats
@@ -27,7 +27,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
     "artifact upload \* : echo uploaded \$3"
 
   stub zip \
-    "\* \* : echo zipped \$2 into \$1"
+    "-r \* \* : echo zipped \$3 into \$2"
 
   run "$PWD/hooks/post-command"
 
@@ -76,7 +76,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
     "artifact upload \* : echo uploaded \$3"
 
   stub zip \
-    "\* \* : echo zipped \$2 into \$1"
+    "-r \* \* : echo zipped \$3 into \$2"
 
   touch /tmp/foo.log
 
@@ -146,7 +146,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
     "artifact upload --job \* \* : echo uploaded \$5 with --job \$4"
 
   stub zip \
-    "\* \* : echo zipped \$2 into \$1"
+    "-r \* \* : echo zipped \$3 into \$2"
 
   run "$PWD/hooks/post-command"
 
@@ -201,7 +201,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
     "artifact upload \* : echo uploaded \$3"
 
   stub zip \
-    "\* \* \* \* : echo zipped \$2, \$3 and \$4 into \$1"
+    "-r \* \* \* \* : echo zipped \$3, \$4 and \$5 into \$2"
 
   run "$PWD/hooks/post-command"
 
@@ -266,7 +266,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
     "artifact upload \* : echo uploaded \$3"
 
   stub zip \
-    "\* \* \* \* : echo zipped \$2, \$3 and \$4 into \$1"
+    "-r \* \* \* \* : echo zipped \$3, \$4 and \$5 into \$2"
 
   run "$PWD/hooks/post-command"
 


### PR DESCRIPTION
The zip compression was missing the `-r` option for recursive paths,

Fixes #88 