### PR TITLE
SUP-1372 fix compressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This functionality duplicates the [artifact_paths](https://buildkite.com/docs/pi
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.9.0:
+    - artifacts#v1.9.1:
         upload: "log/**/*.log"
 ```
 
@@ -20,7 +20,7 @@ You can specify multiple files/globs to upload as artifacts:
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.9.0:
+    - artifacts#v1.9.1:
         upload: [ "log/**/*.log", "debug/*.error" ]
 ```
 
@@ -30,7 +30,7 @@ And even rename them before uploading them (can not use globs here though, sorry
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.9.0:
+    - artifacts#v1.9.1:
         upload: 
           - from: log1.log
             to: log2.log
@@ -47,7 +47,7 @@ eg: uploading a public file when using S3
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.9.0:
+    - artifacts#v1.9.1:
         upload: "coverage-report/**/*"
         s3-upload-acl: public-read
 ```
@@ -57,7 +57,7 @@ eg: uploading a private file when using GS
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.9.0:
+    - artifacts#v1.9.1:
         upload: "coverage-report/**/*"
         gs-upload-acl: private
 ```
@@ -70,7 +70,7 @@ This downloads artifacts matching globs to the local filesystem. See [downloadin
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.9.0:
+      - artifacts#v1.9.1:
           download: "log/**/*.log"
 ```
 
@@ -80,7 +80,7 @@ You can specify multiple files/patterns:
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.9.0:
+      - artifacts#v1.9.1:
           download: [ "log/**/*.log", "debug/*.error" ]
 ```
 
@@ -90,7 +90,7 @@ Rename particular files after downloading them:
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.9.0:
+      - artifacts#v1.9.1:
           download: 
             - from: log1.log
               to: log2.log
@@ -102,7 +102,7 @@ And even do so from different builds/steps:
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.9.0:
+      - artifacts#v1.9.1:
           step: UUID-DEFAULT
           build: UUID-DEFAULT-2
           download: 
@@ -145,7 +145,7 @@ When uploading, the file or directory specified in the `upload` option will be c
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.9.0:
+    - artifacts#v1.9.1:
         upload: "log/my-folder"
         compressed: logs.zip
 ```
@@ -156,7 +156,7 @@ When downloading, this option states the actual name of the artifact to be downl
 steps:
   - command: ...
     plugins:
-      - artifacts#v1.9.0:
+      - artifacts#v1.9.1:
           download: "log/file.log"
           compressed: logs.tgz
 ```
@@ -177,7 +177,7 @@ Skip uploading if the main command failed with exit code 147:
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.9.0:
+    - artifacts#v1.9.1:
         upload: "log/*.log"
         skip-on-status: 147
 ```
@@ -188,7 +188,7 @@ Alternatively, skip artifact uploading on exit codes 1 and 5:
 steps:
   - command: ...
     plugins:
-    - artifacts#v1.9.0:
+    - artifacts#v1.9.1:
         upload: "log/*.log"
         skip-on-status:
           - 1

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ steps:
 
 ### `ignore-missing` (optional, boolean)
 
-If set to `true`, it will ignore errors caused when calling `buildkite-agent artifact` to prevent failures if you expect artifacts not to be present in some situations.
+If set to `true`, it will ignore errors caused when calling `buildkite-agent artifact` to prevent failures if you expect artifacts not to be present in some situations. When using the `compressed` property, it will ignore compressing the artifacts that are not present.
 
 ### `skip-on-status` (optional, integer or array of integers, uploads only)
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -54,11 +54,6 @@ fi
 if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED:-}" ]]; then
   COMPRESSED="true"
 
-  if [[ ! -e "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" ]]; then
-    echo "+++ 🚨 The specified compression path '${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}' does not exist"
-    exit 1
-  fi
-
   if [[ "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" =~ .*\.zip ]]; then
     compress+=("zip" "-r" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}")
   elif [[ "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" =~ .*\.tgz ]]; then
@@ -133,6 +128,10 @@ if [[ "${SINGULAR_UPLOAD_OBJECT}" == "true" ]]; then
 
   if [[ "${COMPRESSED}" == "true" ]]; then
     echo "~~~ Compressing ${path} to ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
+    if [[ ! -e "${path}" ]]; then
+      echo "+++ 🚨 The specified compression path does not exist"
+      exit 1
+    fi
     "${compress[@]}" "${path}"
     path=" ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
   fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -129,15 +129,18 @@ if [[ "${SINGULAR_UPLOAD_OBJECT}" == "true" ]]; then
   if [[ "${COMPRESSED}" == "true" ]]; then
     echo "~~~ Compressing ${path} to ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
     if [[ ! -e "${path}" ]]; then
-      echo "+++ 🚨 The specified compression path does not exist"
-      exit 1
+      echo "+++ 🚨 Unable to compress artifact, '${path}' may not exist or is an empty directory"
+      path=""
+    else
+      "${compress[@]}" "${path}"
+      path=" ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
     fi
-    "${compress[@]}" "${path}"
-    path=" ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
   fi
 
-  echo "~~~ Uploading artifacts ${EXTRA_MESSAGE}"
-  bk_agent "${args[@]}" "${path}"
+  if [[ ! -z "${path}" ]]; then
+    echo "~~~ Uploading artifacts ${EXTRA_MESSAGE}"
+    bk_agent "${args[@]}" "${path}"
+  fi
 elif [[ "${COMPRESSED}" == "true" ]]; then
   final_paths=()
   index=0

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -130,17 +130,14 @@ if [[ "${SINGULAR_UPLOAD_OBJECT}" == "true" ]]; then
     echo "~~~ Compressing ${path} to ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
     if [[ ! -e "${path}" ]]; then
       echo "+++ 🚨 Unable to compress artifact, '${path}' may not exist or is an empty directory"
-      path=""
     else
       "${compress[@]}" "${path}"
       path=" ${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
     fi
   fi
 
-  if [[ -n "${path}" ]]; then
-    echo "~~~ Uploading artifacts ${EXTRA_MESSAGE}"
-    bk_agent "${args[@]}" "${path}"
-  fi
+  echo "~~~ Uploading artifacts ${EXTRA_MESSAGE}"
+  bk_agent "${args[@]}" "${path}"
 elif [[ "${COMPRESSED}" == "true" ]]; then
   final_paths=()
   index=0

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -54,6 +54,11 @@ fi
 if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED:-}" ]]; then
   COMPRESSED="true"
 
+  if [[ ! -e "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" ]]; then
+    echo "+++ 🚨 The specified compression path '${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}' does not exist"
+    exit 1
+  fi
+
   if [[ "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" =~ .*\.zip ]]; then
     compress+=("zip" "-r" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}")
   elif [[ "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}" =~ .*\.tgz ]]; then

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -137,7 +137,7 @@ if [[ "${SINGULAR_UPLOAD_OBJECT}" == "true" ]]; then
     fi
   fi
 
-  if [[ ! -z "${path}" ]]; then
+  if [[ -n "${path}" ]]; then
     echo "~~~ Uploading artifacts ${EXTRA_MESSAGE}"
     bk_agent "${args[@]}" "${path}"
   fi

--- a/tests/upload-compressed.bats
+++ b/tests/upload-compressed.bats
@@ -48,10 +48,10 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 }
 
 @test "Single value zip" {
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="file.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
 
-  touch "*.log"
+  touch "file.log"
 
   stub buildkite-agent \
     "artifact upload \* : echo uploaded \$3"
@@ -62,7 +62,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   run "$PWD/hooks/post-command"
 
   assert_success
-  assert_output --partial "Compressing *.log to file.zip"
+  assert_output --partial "Compressing file.log to file.zip"
   assert_output --partial "Uploading artifacts"
   assert_output --partial "uploaded file.zip"
 
@@ -72,14 +72,14 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
 
-  rm "*.log"
+  rm "file.log"
 }
 
 @test "Single value tgz" {
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="file.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
 
-  touch "*.log"
+  touch "file.log"
 
   stub buildkite-agent \
     "artifact upload \* : echo uploaded \$3"
@@ -90,7 +90,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   run "$PWD/hooks/post-command"
 
   assert_success
-  assert_output --partial "Compressing *.log to file.tgz"
+  assert_output --partial "Compressing file.log to file.tgz"
   assert_output --partial "Uploading artifacts"
   assert_output --partial "uploaded file.tgz"
 
@@ -100,7 +100,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
 
-  rm "*.log"
+  rm "file.log"
 }
 
 @test "Single file zip with relocation" {
@@ -174,11 +174,11 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 }
 
 @test "Single value zip with job" {
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="file.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_JOB="12345"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
 
-  touch "*.log"
+  touch "file.log"
 
   stub buildkite-agent \
     "artifact upload --job \* \* : echo uploaded \$5 with --job \$4"
@@ -190,9 +190,9 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 
   assert_success
   assert_output --partial "Uploading artifacts (extra args: '--job 12345')"
-  assert_output --partial "Compressing *.log to file.zip"
+  assert_output --partial "Compressing file.log to file.zip"
   assert_output --partial "uploaded file.zip"
-  refute_output --partial "uploaded *.log"
+  refute_output --partial "uploaded file.log"
   
   unstub buildkite-agent
   unstub zip
@@ -201,15 +201,15 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unset BUILDKITE_PLUGIN_ARTIFACTS_JOB
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
 
-  rm "*.log"
+  rm "file.log"
 }
 
 @test "Single value tgz with job" {
-  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="file.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_JOB="12345"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
 
-  touch "*.log"
+  touch "file.log"
 
   stub buildkite-agent \
     "artifact upload --job \* \* : echo uploaded \$5 with --job \$4"
@@ -221,9 +221,9 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 
   assert_success
   assert_output --partial "Uploading artifacts (extra args: '--job 12345')"
-  assert_output --partial "Compressing *.log to file.tgz"
+  assert_output --partial "Compressing file.log to file.tgz"
   assert_output --partial "uploaded file.tgz"
-  refute_output --partial "uploaded *.log"
+  refute_output --partial "uploaded file.log"
   
   unstub buildkite-agent
   unstub tar
@@ -232,7 +232,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unset BUILDKITE_PLUGIN_ARTIFACTS_JOB
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
 
-  rm "*.log"
+  rm "file.log"
 }
 
 @test "Multiple artifacts zip" {

--- a/tests/upload-compressed.bats
+++ b/tests/upload-compressed.bats
@@ -5,7 +5,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 # Uncomment to enable stub debug output:
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
-@test "Compression errors silently when there is nothing to compress" {
+@test "Compression fails when there is nothing to compress" {
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="non_existent_file.txt"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
 

--- a/tests/upload-compressed.bats
+++ b/tests/upload-compressed.bats
@@ -9,6 +9,8 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="file.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.rar"
 
+  touch file.rar
+
   run "$PWD/hooks/post-command"
 
   assert_failure
@@ -17,11 +19,15 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+
+  rm file.rar
 }
 
 @test "Single value zip" {
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
+
+  touch file.zip
 
   stub buildkite-agent \
     "artifact upload \* : echo uploaded \$3"
@@ -41,11 +47,15 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+
+  rm file.zip
 }
 
 @test "Single value tgz" {
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
+
+  touch file.tgz
 
   stub buildkite-agent \
     "artifact upload \* : echo uploaded \$3"
@@ -65,12 +75,16 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+
+  rm file.tgz
 }
 
 @test "Single file zip with relocation" {
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM="/tmp/foo.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_TO="/tmp/foo2.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
+
+  touch file.zip
 
   stub buildkite-agent \
     "artifact upload \* : echo uploaded \$3"
@@ -107,6 +121,8 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_TO="/tmp/foo2.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
 
+  touch file.tgz
+
   stub buildkite-agent \
     "artifact upload \* : echo uploaded \$3"
 
@@ -135,12 +151,16 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM
   unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+
+  rm file.tgz
 }
 
 @test "Single value zip with job" {
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_JOB="12345"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
+
+  touch file.zip
 
   stub buildkite-agent \
     "artifact upload --job \* \* : echo uploaded \$5 with --job \$4"
@@ -162,12 +182,16 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
   unset BUILDKITE_PLUGIN_ARTIFACTS_JOB
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+
+  rm file.zip
 }
 
 @test "Single value tgz with job" {
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="*.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_JOB="12345"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
+
+  touch file.tgz
 
   stub buildkite-agent \
     "artifact upload --job \* \* : echo uploaded \$5 with --job \$4"
@@ -197,6 +221,8 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2="baz.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
 
+  touch file.zip
+
   stub buildkite-agent \
     "artifact upload \* : echo uploaded \$3"
 
@@ -220,6 +246,8 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+
+  rm file.zip
 }
 
 @test "Multiple artifacts tgz" {
@@ -227,6 +255,8 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1="bar.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2="baz.log"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
+
+  touch file.tgz
 
   stub buildkite-agent \
     "artifact upload \* : echo uploaded \$3"
@@ -251,6 +281,8 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+
+  rm file.tgz
 }
 
 @test "Multiple artifacs zip some relocation" {
@@ -261,6 +293,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
 
   touch /tmp/foo.log
+  touch file.zip
 
   stub buildkite-agent \
     "artifact upload \* : echo uploaded \$3"
@@ -291,6 +324,8 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+
+  rm file.zip
 }
 
 @test "Multiple artifacs tgz some relocation" {
@@ -301,6 +336,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.tgz"
 
   touch /tmp/foo.log
+  touch file.tgz
 
   stub buildkite-agent \
     "artifact upload \* : echo uploaded \$3"
@@ -331,6 +367,8 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
+
+  rm file.tgz
 }
 
 @test "Post-command does nothing if no vars are set" {

--- a/tests/upload-compressed.bats
+++ b/tests/upload-compressed.bats
@@ -5,16 +5,15 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 # Uncomment to enable stub debug output:
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
-@test "Compression without path existence" {
+@test "Compression fails silently when there is nothing to compress" {
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="non_existent_file.txt"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
 
   run "$PWD/hooks/post-command"
 
-  assert_failure
-  assert_output --partial "The specified compression path does not exist"
+  assert_success
+  assert_output --partial "Unable to compress artifact, 'non_existent_file.txt' may not exist or is an empty directory"
   refute_output --partial "Uploading artifacts"
-  refute [ -e "non_existent_file.txt" ]
 
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED

--- a/tests/upload-compressed.bats
+++ b/tests/upload-compressed.bats
@@ -18,7 +18,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unset BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED
 }
 
-@test "Compression errors silently when there is nothing to compress and ignore-missing is set to true" {
+@test "Compression ignored when there is nothing to compress and ignore-missing is set to true" {
   export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD="non_existent_file.txt"
   export BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED="file.zip"
   export BUILDKITE_PLUGIN_ARTIFACTS_IGNORE_MISSING="true"


### PR DESCRIPTION
This PR adds a check to the **compressed:** setting to make sure the file or directory exists before attempting to compress. It will also **not** attempt to compress if the file/folder is either missing or empty, but display an error message about being unable to compress, and then continue on running instead of outright failing.

A new test has been added to check for path existence on **compressed:** for the expected graceful error and continue message.

A new test has been added to check for path existence on **compressed** when **ignore-missing** is set for the expected graceful error and continue message.

The rest of the affected failing tests have also been updated to create each tests mock file and delete it after the test is done so the tests no longer fail due to the new existence check.

This will fix #89 