### PR TITLE
Add support for path key

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,9 @@ steps:
           step: UUID-DEFAULT
           build: UUID-DEFAULT-2
           download: 
-            - from: log1.log
-              to: log2.log
+            - path: log1.log
               step: UUID-1
-            - from: log3.log
-              to: log4.log
+            - path: log3.log
               build: UUID-2
 ```
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -8,7 +8,7 @@ fi
 
 while IFS='=' read -r EXIT_VAR _ ; do
   if [[ $EXIT_VAR =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_SKIP_ON_STATUS(|_[0-9]+))$ ]]; then
-    if [ "${BUILDKITE_COMMAND_EXIT_STATUS}" -eq "${!EXIT_VAR}" ]; then
+    if ((BUILDKITE_COMMAND_EXIT_STATUS == ${!EXIT_VAR})); then
       echo "Command exit status matches ${!EXIT_VAR}, skipping upload"
       exit 0
     fi
@@ -40,7 +40,7 @@ while IFS='=' read -r path _ ; do
   fi
 done < <(env | sort)
 
-if [[ "${#paths[@]}" -le 0 ]]; then
+if ((${#paths[@]} <= 0)); then
   # no upload data
   exit 0
 fi
@@ -106,7 +106,7 @@ if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_GS_UPLOAD_ACL:-}" ]] ; then
   export BUILDKITE_GS_ACL="${BUILDKITE_PLUGIN_ARTIFACTS_GS_UPLOAD_ACL}"
 fi
 
-if [[ "${#args[@]}" -gt 1 ]]; then
+if ((${#args[@]} > 1)); then
   EXTRA_MESSAGE="(extra args: '${args[*]:1}')"
 else
   EXTRA_MESSAGE=""

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -31,14 +31,21 @@ UPLOAD="single"
 while IFS='=' read -r path _ ; do
   if [[ $path == BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD ]]; then
     paths+=("${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD}")
+  elif [[ $path == BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_PATH ]]; then
+    paths+=("${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_PATH}")
   elif [[ $path == BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM ]] && [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_TO:-}" ]]; then
     RELOCATION="true"
     paths+=("${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM}")
-  elif [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]+) ]] && ! [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]+_TO) ]]; then
+  elif { [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]+) ]] || [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]+_PATH) ]]; } && ! [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]+_TO) ]]; then
     UPLOAD="multiple"
     paths+=("${!path}")
   fi
 done < <(env | sort)
+
+if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_PATH:-}" ]] && [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM:-}" ]]; then
+  echo "+++ 🚨 Both 'path' and 'from' keys found, only one may be provided"
+  exit 1
+fi
 
 if ((${#paths[@]} <= 0)); then
   # no upload data
@@ -156,8 +163,22 @@ elif [[ "${UPLOAD}" == "multiple" ]]; then
   echo "~~~ Uploading artifacts ${EXTRA_MESSAGE}"
 
   for path in "${paths[@]}"; do
-    handle_relocation "${index}"
+    path_env_var="BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_${index}_PATH"
+    source_env_var="BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_${index}_FROM"
     dest_env_var="BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_${index}_TO"
+
+    # path must not be used with to/from keys
+    if [[ -n "${!path_env_var:-}" ]]; then
+      if [[ -n "${!source_env_var:-}" ]]; then
+        echo "+++ 🚨 Both 'path' and 'from' keys found at index $index, only one may be provided"
+        exit 1
+      elif [[ -n "${!dest_env_var:-}" ]]; then
+        echo "+++ 🚨 Both 'path' and 'to' keys found at index $index, 'to' must be paired with 'from' key not 'path'"
+        exit 1
+      fi
+    fi
+
+    handle_relocation "${index}"
     if [[ -n "${!dest_env_var:-}" ]]; then
       path="${!dest_env_var}"
     fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -26,22 +26,16 @@ compress=()
 
 COMPRESSED="false"
 RELOCATION="false"
-SINGULAR_UPLOAD_OBJECT="false"
-MULTIPLE_UPLOADS="false"
-
-if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD:-}" ]] || { [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM:-}" ]] && [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_TO:-}" ]]; }; then
-  SINGULAR_UPLOAD_OBJECT="true"
-  if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD:-}" ]] ; then
-    paths+=("${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD}")
-  elif [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM:-}" ]] && [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_TO:-}" ]] ; then
-    RELOCATION="true"
-    paths+=("${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM}")
-  fi
-fi
+UPLOAD="single"
 
 while IFS='=' read -r path _ ; do
-  if [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]+) ]] && ! [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]+_TO) ]]; then
-    MULTIPLE_UPLOADS="true"
+  if [[ $path == BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD ]]; then
+    paths+=("${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD}")
+  elif [[ $path == BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM ]] && [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_TO:-}" ]]; then
+    RELOCATION="true"
+    paths+=("${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_FROM}")
+  elif [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]+) ]] && ! [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_[0-9]+_TO) ]]; then
+    UPLOAD="multiple"
     paths+=("${!path}")
   fi
 done < <(env | sort)
@@ -118,7 +112,7 @@ else
   EXTRA_MESSAGE=""
 fi
 
-if [[ "${SINGULAR_UPLOAD_OBJECT}" == "true" ]]; then
+if [[ "${UPLOAD}" == "single" ]]; then
   if [[ "${RELOCATION}" == "true" ]]; then
     handle_relocation ""
     path="${BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_TO}"
@@ -157,7 +151,7 @@ elif [[ "${COMPRESSED}" == "true" ]]; then
 
   echo "~~~ Uploading artifacts ${EXTRA_MESSAGE}"
   bk_agent "${args[@]}" "${BUILDKITE_PLUGIN_ARTIFACTS_COMPRESSED}"
-elif [[ "${MULTIPLE_UPLOADS}" == "true" ]]; then
+elif [[ "${UPLOAD}" == "multiple" ]]; then
   index=0
   echo "~~~ Uploading artifacts ${EXTRA_MESSAGE}"
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -19,14 +19,21 @@ RELOCATION="false"
 while IFS='=' read -r path _ ; do
   if [[ $path == BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD ]]; then
     paths+=("$BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD")
+  elif [[ $path == BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_PATH ]]; then
+    paths+=("$BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_PATH")
   elif [[ $path == BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM ]] && [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO:-}" ]]; then
     RELOCATION="true"
     paths+=("$BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM")
-  elif [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+)$ ]] || [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+_FROM)$ ]]; then
+  elif [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+)$ ]] || [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+_PATH)$ ]] || [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+_FROM)$ ]]; then
     DOWNLOAD="multiple"
     paths+=("${!path}")
   fi
 done < <(env | sort)
+
+if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_PATH:-}" ]] && [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM:-}" ]]; then
+  echo "+++ 🚨 Both 'path' and 'from' keys found, only one may be provided"
+  exit 1
+fi
 
 if ((${#paths[@]} <= 0)); then
   # no download data
@@ -141,10 +148,22 @@ elif [[ "${DOWNLOAD}" == "multiple" ]]; then
   index=0
 
   for path in "${paths[@]}"; do
+    path_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_PATH"
     source_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_FROM"
     dest_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_TO"
     step_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_STEP"
     build_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_BUILD"
+
+    # path must not be used with to/from keys
+    if [[ -n "${!path_env_var:-}" ]]; then
+      if [[ -n "${!source_env_var:-}" ]]; then
+        echo "+++ 🚨 Both 'path' and 'from' keys found at index $index, only one may be provided"
+        exit 1
+      elif [[ -n "${!dest_env_var:-}" ]]; then
+        echo "+++ 🚨 Both 'path' and 'to' keys found at index $index, 'to' must be paired with 'from' key not 'path'"
+        exit 1
+      fi
+    fi
 
     # finally get the artifact to download
     if [[ -n "${!source_env_var:-}" ]] && [[ -n "${!dest_env_var:-}" ]]; then

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -28,7 +28,7 @@ while IFS='=' read -r path _ ; do
   fi
 done < <(env | sort)
 
-if [[ "${#paths[@]}" -le 0 ]]; then
+if ((${#paths[@]} <= 0)); then
   # no download data
   exit 0
 fi
@@ -41,15 +41,15 @@ bk_agent() {
   shift
 
   options=('download')
-  if [ -n "$step" ]; then
+  if [[ -n "$step" ]]; then
     options+=("--step" "${step}")
   fi
 
-  if [ -n "$build" ]; then
+  if [[ -n "$build" ]]; then
     options+=("--build" "${build}")
   fi
 
-  if [[ "${#options[@]}" -gt 1 ]]; then
+  if ((${#options[@]} > 1)); then
     EXTRA_MESSAGE="(extra args: '${options[*]:1}')"
   else
     EXTRA_MESSAGE=""
@@ -147,7 +147,7 @@ elif [[ "${DOWNLOAD}" == "multiple" ]]; then
     build_env_var="BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_${index}_BUILD"
 
     # finally get the artifact to download
-    if [ -n "${!source_env_var:-}" ] && [ -n "${!dest_env_var:-}" ]; then
+    if [[ -n "${!source_env_var:-}" ]] && [[ -n "${!dest_env_var:-}" ]]; then
       source="${!source_env_var}"
     else
       source="${path}"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -13,23 +13,17 @@ paths=()
 compress=()
 
 COMPRESSED="false"
-SINGULAR_DOWNLOAD_OBJECT="false"
+DOWNLOAD="single"
 RELOCATION="false"
-MULTIPLE_DOWNLOADS="false"
-
-if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD:-}" ]] || { [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM:-}" ]] && [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO:-}" ]]; }; then
-    SINGULAR_DOWNLOAD_OBJECT="true"
-    if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD:-}" ]] ; then
-      paths+=("$BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD")
-    elif [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM:-}" ]] && [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO:-}" ]] ; then
-      RELOCATION="true"
-      paths+=("$BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM")
-    fi
-fi
 
 while IFS='=' read -r path _ ; do
-  if [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+)$ ]] || [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+_FROM)$ ]]; then
-    MULTIPLE_DOWNLOADS="true"
+  if [[ $path == BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD ]]; then
+    paths+=("$BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD")
+  elif [[ $path == BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM ]] && [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO:-}" ]]; then
+    RELOCATION="true"
+    paths+=("$BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM")
+  elif [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+)$ ]] || [[ $path =~ ^(BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_[0-9]+_FROM)$ ]]; then
+    DOWNLOAD="multiple"
     paths+=("${!path}")
   fi
 done < <(env | sort)
@@ -131,7 +125,7 @@ if [[ "${COMPRESSED}" == "true" ]]; then
     ((index+=1))
   done
 
-elif [[ "${SINGULAR_DOWNLOAD_OBJECT}" == "true" ]]; then
+elif [[ "${DOWNLOAD}" == "single" ]]; then
   if [[ "${RELOCATION}" == "true" ]]; then
     source="${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_FROM}"
   else
@@ -143,7 +137,7 @@ elif [[ "${SINGULAR_DOWNLOAD_OBJECT}" == "true" ]]; then
   if [[ -n "${BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_TO:-}" ]]; then
     handle_relocation ""
   fi
-elif [[ "${MULTIPLE_DOWNLOADS}" == "true" ]]; then
+elif [[ "${DOWNLOAD}" == "multiple" ]]; then
   index=0
 
   for path in "${paths[@]}"; do

--- a/plugin.yml
+++ b/plugin.yml
@@ -8,6 +8,8 @@ configuration:
     from-to-object:
       type: object
       properties:
+        path:
+          type: string
         from:
           type: string
         to:
@@ -17,8 +19,9 @@ configuration:
         build:
           type: string
       required:
-        - from
-        - to
+        oneOf:
+          - [from, to]
+          - path
   properties:
     upload:
       oneOf:

--- a/tests/download.bats
+++ b/tests/download.bats
@@ -288,3 +288,37 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_FROM
   unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_TO
 }
+
+@test "Pre-command downloads artifacts with path" {
+  stub buildkite-agent \
+    "artifact download \* \* : echo downloaded artifact \$3 to \$4"
+
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_PATH="*.log"
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts"
+
+  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_PATH
+}
+
+@test "Pre-command downloads multiple artifacts with path" {
+  stub buildkite-agent \
+    "artifact download \* \* : echo downloaded artifact \$3 to \$4" \
+    "artifact download \* \* : echo downloaded artifact \$3 to \$4" \
+    "artifact download \* \* : echo downloaded artifact \$3 to \$4"
+
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_PATH="foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1_PATH="bar.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2_PATH="baz.log"
+  run "$PWD/hooks/pre-command"
+
+  assert_success
+  assert_output --partial "Downloading artifacts"
+
+  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_0_PATH
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_1_PATH
+  unset BUILDKITE_PLUGIN_ARTIFACTS_DOWNLOAD_2_PATH
+}

--- a/tests/upload.bats
+++ b/tests/upload.bats
@@ -283,3 +283,38 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   refute_output --partial "Uploading artifacts"
   assert_output --partial "skipping upload"
 }
+
+@test "Post-command uploads artifacts with a single value for upload with path" {
+  stub buildkite-agent \
+    "artifact upload \* : echo uploaded \$3"
+
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_PATH="*.log"
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Uploading artifacts"
+  refute_output --partial "extra args"
+
+  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_PATH
+}
+
+@test "Post-command uploads multiple artifacts with path" {
+  stub buildkite-agent \
+    "artifact upload \* : echo uploaded \$3" \
+    "artifact upload \* : echo uploaded \$3" \
+    "artifact upload \* : echo uploaded \$3"
+
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_PATH="/tmp/foo.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1_PATH="bar.log"
+  export BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2_PATH="baz.log"
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial "Uploading artifacts"
+
+  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_0_PATH
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_1_PATH
+  unset BUILDKITE_PLUGIN_ARTIFACTS_UPLOAD_2_PATH
+}


### PR DESCRIPTION
This PR adds support for `path` keys. This way we can make use of `build` or `step` without relocation. Also cleaned up a few things along the way like always using `[[ ]]` and `(( ))` to make tests/arithmetic consistent within the file. I found it easier to reason about the single/multiple discovery by doing it all in the loop but would be fine dropping that if wanted.